### PR TITLE
🐛  소셜 로그인 로직 오류 수정 (#29)

### DIFF
--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/out/MemberPersistence.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/out/MemberPersistence.kt
@@ -16,8 +16,12 @@ class MemberPersistence(
         return memberRepository.save(memberEntity).id
     }
 
-    override fun getMember(memberId: Long): MemberEntity{
+    override fun getMember(memberId: Long): MemberEntity {
         return memberRepository.findById(memberId)
                 .orElseThrow { throw AdapterException(ResponseCode.INVALID_DOMAIN) }
+    }
+
+    override fun findMember(providerUserId: String): MemberEntity? {
+        return memberRepository.findByProviderUserId(providerUserId)
     }
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/out/MemberRepository.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/out/MemberRepository.kt
@@ -4,4 +4,6 @@ import backend.team.ahachul_backend.api.member.domain.entity.MemberEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface MemberRepository: JpaRepository<MemberEntity, Long> {
+
+    fun findByProviderUserId(providerUserId: String): MemberEntity?
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/out/MemberReader.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/out/MemberReader.kt
@@ -5,4 +5,6 @@ import backend.team.ahachul_backend.api.member.domain.entity.MemberEntity
 interface MemberReader {
 
     fun getMember(memberId: Long): MemberEntity
+
+    fun findMember(providerUserId: String): MemberEntity?
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/impl/KakaoMemberClientImpl.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/impl/KakaoMemberClientImpl.kt
@@ -29,12 +29,11 @@ class KakaoMemberClientImpl(
             contentType = MediaType.APPLICATION_FORM_URLENCODED
         }
 
-        val params = linkedMapOf(
-                "grant_type" to "authorization_code",
-                "client_id" to oAuthProperties.client["kakao"]!!.clientId,
-                "redirect_uri" to oAuthProperties.client["kakao"]!!.redirectUri,
-                "code" to code
-        )
+        val params = LinkedMultiValueMap<String, String>()
+        params.add("grant_type", "authorization_code")
+        params.add("client_id", oAuthProperties.client["kakao"]!!.clientId)
+        params.add("redirect_uri", oAuthProperties.client["kakao"]!!.redirectUri)
+        params.add("code", code)
 
         val request = HttpEntity(params, headers)
         val url = oAuthProperties.provider["kakao"]!!.tokenUri

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/interceptor/AuthenticationInterceptor.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/interceptor/AuthenticationInterceptor.kt
@@ -1,6 +1,5 @@
 package backend.team.ahachul_backend.common.interceptor
 
-import backend.team.ahachul_backend.api.member.application.port.out.MemberReader
 import backend.team.ahachul_backend.common.annotation.Authentication
 import backend.team.ahachul_backend.common.exception.CommonException
 import backend.team.ahachul_backend.common.response.ResponseCode
@@ -18,7 +17,6 @@ import org.springframework.web.servlet.HandlerInterceptor
 
 @Component
 class AuthenticationInterceptor(
-        private val memberReader: MemberReader,
         private val jwtUtils: JwtUtils
 ): HandlerInterceptor {
 
@@ -30,10 +28,7 @@ class AuthenticationInterceptor(
             val jwtToken = request.getHeader("Authorization")
             val verifiedJwtToken = jwtUtils.verify(jwtToken)
 
-            val member = memberReader.getMember(verifiedJwtToken.body.subject.toLong())
-
-            RequestUtils.setAttribute("memberId", member.id!!)
-            RequestUtils.setAttribute("nickname", member.nickname!!)
+            RequestUtils.setAttribute("memberId", verifiedJwtToken.body.subject)
 
         } catch (e: Exception) {
             when (e) {


### PR DESCRIPTION
## 📚 개요
- #29 

## ✏️ 작업 내용
- 신규 회원일 경우에 회원 저장
- 카카오 인증 파라미터 컬렉션 변경

## 💡 주의 사항
- 인증 인터셉터에 유저 조회 하는 부분 제거하는 것도 포함시켰습니다.