### PR TITLE
[FEATURE] 닉네임 중복 여부 검증 API 구현 & 사용자 정보 수정 API validation 변경 (#52)

### DIFF
--- a/ahachul_backend/src/docs/asciidoc/index.adoc
+++ b/ahachul_backend/src/docs/asciidoc/index.adoc
@@ -80,6 +80,17 @@ include::{snippets}/update-member/http-response.adoc[]
 .Response Fields
 include::{snippets}/update-member/response-fields.adoc[]
 
+==== 사용자 닉네임 중복 체크
+
+.Request
+include::{snippets}/check-nickname/http-request.adoc[]
+.Request Fields
+include::{snippets}/check-nickname/request-fields.adoc[]
+.Response
+include::{snippets}/check-nickname/http-response.adoc[]
+.Response Fields
+include::{snippets}/check-nickname/response-fields.adoc[]
+
 === 에러 코드
 
 |===

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/MemberController.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/MemberController.kt
@@ -1,5 +1,6 @@
 package backend.team.ahachul_backend.api.member.adapter.web.`in`
 
+import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.CheckNicknameDto
 import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.GetMemberDto
 import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.UpdateMemberDto
 import backend.team.ahachul_backend.api.member.application.port.`in`.MemberUseCase
@@ -7,6 +8,7 @@ import backend.team.ahachul_backend.common.annotation.Authentication
 import backend.team.ahachul_backend.common.response.CommonResponse
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 
@@ -25,5 +27,10 @@ class MemberController(
     @PatchMapping("/v1/members")
     fun updateMember(@RequestBody request: UpdateMemberDto.Request): CommonResponse<UpdateMemberDto.Response> {
         return CommonResponse.success(memberUseCase.updateMember(request.toCommand()))
+    }
+
+    @PostMapping("/v1/members/check-nickname")
+    fun checkNickname(@RequestBody request: CheckNicknameDto.Request): CommonResponse<CheckNicknameDto.Response> {
+        return CommonResponse.success(memberUseCase.checkNickname(request.toCommand()))
     }
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/dto/CheckNicknameDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/dto/CheckNicknameDto.kt
@@ -1,0 +1,31 @@
+package backend.team.ahachul_backend.api.member.adapter.web.`in`.dto
+
+import backend.team.ahachul_backend.api.member.application.port.`in`.command.CheckNicknameCommand
+import org.jetbrains.annotations.NotNull
+
+class CheckNicknameDto {
+    data class Request(
+            @NotNull
+            val nickname: String,
+    ) {
+
+        fun toCommand(): CheckNicknameCommand {
+            return CheckNicknameCommand(
+                nickname = nickname
+            )
+        }
+    }
+
+    data class Response(
+            val available: Boolean,
+    ) {
+
+        companion object {
+            fun of(available: Boolean): Response {
+                return Response(
+                    available = available
+                )
+            }
+        }
+    }
+}

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/dto/UpdateMemberDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/dto/UpdateMemberDto.kt
@@ -5,9 +5,9 @@ import backend.team.ahachul_backend.api.member.domain.model.GenderType
 
 class UpdateMemberDto {
     data class Request(
-            val nickname: String,
-            val gender: GenderType,
-            val ageRange: String,
+            val nickname: String?,
+            val gender: GenderType?,
+            val ageRange: String?,
     ) {
         fun toCommand(): UpdateMemberCommand {
             return UpdateMemberCommand(

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/dto/UpdateMemberDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/dto/UpdateMemberDto.kt
@@ -2,15 +2,11 @@ package backend.team.ahachul_backend.api.member.adapter.web.`in`.dto
 
 import backend.team.ahachul_backend.api.member.application.port.`in`.command.UpdateMemberCommand
 import backend.team.ahachul_backend.api.member.domain.model.GenderType
-import org.jetbrains.annotations.NotNull
 
 class UpdateMemberDto {
     data class Request(
-            @NotNull
             val nickname: String,
-            @NotNull
             val gender: GenderType,
-            @NotNull
             val ageRange: String,
     ) {
         fun toCommand(): UpdateMemberCommand {

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/out/MemberPersistence.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/out/MemberPersistence.kt
@@ -24,4 +24,8 @@ class MemberPersistence(
     override fun findMember(providerUserId: String): MemberEntity? {
         return memberRepository.findByProviderUserId(providerUserId)
     }
+
+    override fun existMember(nickname: String): Boolean {
+        return memberRepository.existsByNickname(nickname)
+    }
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/out/MemberRepository.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/out/MemberRepository.kt
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 interface MemberRepository: JpaRepository<MemberEntity, Long> {
 
     fun findByProviderUserId(providerUserId: String): MemberEntity?
+
+    fun existsByNickname(nickname: String): Boolean
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/in/MemberUseCase.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/in/MemberUseCase.kt
@@ -1,12 +1,16 @@
 package backend.team.ahachul_backend.api.member.application.port.`in`
 
+import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.CheckNicknameDto
 import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.GetMemberDto
 import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.UpdateMemberDto
+import backend.team.ahachul_backend.api.member.application.port.`in`.command.CheckNicknameCommand
 import backend.team.ahachul_backend.api.member.application.port.`in`.command.UpdateMemberCommand
 
 interface MemberUseCase {
 
     fun getMember(): GetMemberDto.Response
 
-    fun updateMember(updateMemberCommand: UpdateMemberCommand): UpdateMemberDto.Response
+    fun updateMember(command: UpdateMemberCommand): UpdateMemberDto.Response
+
+    fun checkNickname(command: CheckNicknameCommand): CheckNicknameDto.Response
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/in/command/CheckNicknameCommand.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/in/command/CheckNicknameCommand.kt
@@ -1,0 +1,6 @@
+package backend.team.ahachul_backend.api.member.application.port.`in`.command
+
+data class CheckNicknameCommand(
+        val nickname: String,
+) {
+}

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/in/command/UpdateMemberCommand.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/in/command/UpdateMemberCommand.kt
@@ -3,8 +3,8 @@ package backend.team.ahachul_backend.api.member.application.port.`in`.command
 import backend.team.ahachul_backend.api.member.domain.model.GenderType
 
 data class UpdateMemberCommand(
-        val nickname: String,
-        val gender: GenderType,
-        val ageRange: String,
+        val nickname: String?,
+        val gender: GenderType?,
+        val ageRange: String?,
 ) {
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/out/MemberReader.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/out/MemberReader.kt
@@ -7,4 +7,6 @@ interface MemberReader {
     fun getMember(memberId: Long): MemberEntity
 
     fun findMember(providerUserId: String): MemberEntity?
+
+    fun existMember(nickname: String): Boolean
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/service/MemberService.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/service/MemberService.kt
@@ -25,9 +25,9 @@ class MemberService(
     @Transactional
     override fun updateMember(command: UpdateMemberCommand): UpdateMemberDto.Response {
         val member = memberReader.getMember(RequestUtils.getAttribute("memberId").toLong())
-        member.changeNickname(command.nickname)
-        member.changeGender(command.gender)
-        member.changeAgeRange(command.ageRange)
+        command.nickname?.let { member.changeNickname(it) }
+        command.gender?.let { member.changeGender(it) }
+        command.ageRange?.let { member.changeAgeRange(it) }
         return UpdateMemberDto.Response.of(
                 nickname = member.nickname!!,
                 gender = member.gender!!,

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/service/MemberService.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/service/MemberService.kt
@@ -1,8 +1,10 @@
 package backend.team.ahachul_backend.api.member.application.service
 
+import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.CheckNicknameDto
 import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.GetMemberDto
 import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.UpdateMemberDto
 import backend.team.ahachul_backend.api.member.application.port.`in`.MemberUseCase
+import backend.team.ahachul_backend.api.member.application.port.`in`.command.CheckNicknameCommand
 import backend.team.ahachul_backend.api.member.application.port.`in`.command.UpdateMemberCommand
 import backend.team.ahachul_backend.api.member.application.port.out.MemberReader
 import backend.team.ahachul_backend.common.utils.RequestUtils
@@ -21,15 +23,21 @@ class MemberService(
     }
 
     @Transactional
-    override fun updateMember(updateMemberCommand: UpdateMemberCommand): UpdateMemberDto.Response {
+    override fun updateMember(command: UpdateMemberCommand): UpdateMemberDto.Response {
         val member = memberReader.getMember(RequestUtils.getAttribute("memberId").toLong())
-        member.changeNickname(updateMemberCommand.nickname)
-        member.changeGender(updateMemberCommand.gender)
-        member.changeAgeRange(updateMemberCommand.ageRange)
+        member.changeNickname(command.nickname)
+        member.changeGender(command.gender)
+        member.changeAgeRange(command.ageRange)
         return UpdateMemberDto.Response.of(
                 nickname = member.nickname!!,
                 gender = member.gender!!,
                 ageRange = member.ageRange!!
+        )
+    }
+
+    override fun checkNickname(command: CheckNicknameCommand): CheckNicknameDto.Response {
+        return CheckNicknameDto.Response.of(
+            available = !memberReader.existMember(command.nickname)
         )
     }
 }

--- a/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/MemberControllerDocsTest.kt
+++ b/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/MemberControllerDocsTest.kt
@@ -82,7 +82,7 @@ class MemberControllerDocsTest(
                                 fieldWithPath("result.nickname").type(JsonFieldType.STRING).description("사용자 닉네임").optional(),
                                 fieldWithPath("result.email").type(JsonFieldType.STRING).description("사용자 이메일").optional(),
                                 fieldWithPath("result.gender").type("GenderType").description("사용자 성별. EX) MALE, FEMALE").optional(),
-                                fieldWithPath("result.ageRange").type(JsonFieldType.STRING).description("사용자 연령대").optional(),
+                                fieldWithPath("result.ageRange").type(JsonFieldType.STRING).description("사용자 연령대 EX) 1, 10, 20, 30 ...").optional(),
                         ))
                 )
     }
@@ -125,7 +125,7 @@ class MemberControllerDocsTest(
                         requestFields(
                                 fieldWithPath("nickname").type(JsonFieldType.STRING).description("사용자 닉네임").optional(),
                                 fieldWithPath("gender").type("GenderType").description("사용자 성별. EX) MALE, FEMALE").optional(),
-                                fieldWithPath("ageRange").type(JsonFieldType.STRING).description("사용자 연령대").optional(),
+                                fieldWithPath("ageRange").type(JsonFieldType.STRING).description("사용자 연령대 EX) 1, 10, 20, 30 ...").optional(),
 
                         ),
                         responseFields(
@@ -133,7 +133,7 @@ class MemberControllerDocsTest(
                                 fieldWithPath("message").type(JsonFieldType.STRING).description("상태 메시지"),
                                 fieldWithPath("result.nickname").type(JsonFieldType.STRING).description("사용자 닉네임"),
                                 fieldWithPath("result.gender").type("GenderType").description("사용자 성별. EX) MALE, FEMALE"),
-                                fieldWithPath("result.ageRange").type(JsonFieldType.STRING).description("사용자 연령대"),
+                                fieldWithPath("result.ageRange").type(JsonFieldType.STRING).description("사용자 연령대 EX) 1, 10, 20, 30 ..."),
                         ))
                 )
     }

--- a/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/MemberControllerDocsTest.kt
+++ b/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/MemberControllerDocsTest.kt
@@ -123,9 +123,9 @@ class MemberControllerDocsTest(
                                 headerWithName("Authorization").description("엑세스 토큰")
                         ),
                         requestFields(
-                                fieldWithPath("nickname").type(JsonFieldType.STRING).description("사용자 닉네임"),
-                                fieldWithPath("gender").type("GenderType").description("사용자 성별. EX) MALE, FEMALE"),
-                                fieldWithPath("ageRange").type(JsonFieldType.STRING).description("사용자 연령대"),
+                                fieldWithPath("nickname").type(JsonFieldType.STRING).description("사용자 닉네임").optional(),
+                                fieldWithPath("gender").type("GenderType").description("사용자 성별. EX) MALE, FEMALE").optional(),
+                                fieldWithPath("ageRange").type(JsonFieldType.STRING).description("사용자 연령대").optional(),
 
                         ),
                         responseFields(

--- a/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/MemberControllerDocsTest.kt
+++ b/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/MemberControllerDocsTest.kt
@@ -1,5 +1,6 @@
 package backend.team.ahachul_backend.api.member.adapter.web.`in`
 
+import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.CheckNicknameDto
 import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.GetMemberDto
 import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.UpdateMemberDto
 import backend.team.ahachul_backend.api.member.application.port.`in`.MemberUseCase
@@ -20,8 +21,7 @@ import org.springframework.http.MediaType
 import org.springframework.restdocs.headers.HeaderDocumentation.headerWithName
 import org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document
-import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get
-import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*
 import org.springframework.restdocs.operation.preprocess.Preprocessors
 import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest
 import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse
@@ -136,6 +136,44 @@ class MemberControllerDocsTest(
                                 fieldWithPath("result.ageRange").type(JsonFieldType.STRING).description("사용자 연령대"),
                         ))
                 )
+    }
+
+    @Test
+    fun checkNicknameTest() {
+        // given
+        val response = CheckNicknameDto.Response(
+            available = true
+        )
+
+        given(memberUseCase.checkNickname(any()))
+            .willReturn(response)
+
+        val request = CheckNicknameDto.Request(
+            nickname = "nickname"
+        )
+
+        // when
+        val result = mockMvc.perform(
+            post("/v1/members/check-nickname")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .accept(MediaType.APPLICATION_JSON)
+        )
+
+        // then
+        result.andExpect(status().isOk)
+            .andDo(document("check-nickname",
+                preprocessRequest(Preprocessors.prettyPrint()),
+                preprocessResponse(Preprocessors.prettyPrint()),
+                requestFields(
+                    fieldWithPath("nickname").type(JsonFieldType.STRING).description("사용자 닉네임"),
+                    ),
+                responseFields(
+                    fieldWithPath("code").type(JsonFieldType.STRING).description("상태 코드"),
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("상태 메시지"),
+                    fieldWithPath("result.available").type(JsonFieldType.BOOLEAN).description("닉네임 사용 가능 여부"),
+                ))
+            )
     }
 
     private fun <T> any(): T {

--- a/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/member/application/service/MemberServiceTest.kt
+++ b/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/member/application/service/MemberServiceTest.kt
@@ -2,6 +2,7 @@ package backend.team.ahachul_backend.api.member.application.service
 
 import backend.team.ahachul_backend.api.member.adapter.web.out.MemberRepository
 import backend.team.ahachul_backend.api.member.application.port.`in`.MemberUseCase
+import backend.team.ahachul_backend.api.member.application.port.`in`.command.CheckNicknameCommand
 import backend.team.ahachul_backend.api.member.application.port.`in`.command.UpdateMemberCommand
 import backend.team.ahachul_backend.api.member.domain.entity.MemberEntity
 import backend.team.ahachul_backend.api.member.domain.model.GenderType
@@ -70,5 +71,25 @@ class MemberServiceTest(
         assertThat(result.nickname).isEqualTo("afterNickname")
         assertThat(result.gender).isEqualTo(GenderType.FEMALE)
         assertThat(result.ageRange).isEqualTo("30")
+    }
+
+    @Test
+    @DisplayName("사용자 닉네임 사용 가능 여부 체크")
+    fun 사용자_닉네임_사용가능_여부_체크() {
+        // given
+        val availableCommand = CheckNicknameCommand(
+            nickname = "nickname2"
+        )
+        val unavailableCommand = CheckNicknameCommand(
+            nickname = "nickname"
+        )
+
+        // when
+        val availableResult = memberUseCase.checkNickname(availableCommand)
+        val unavailableResult = memberUseCase.checkNickname(unavailableCommand)
+
+        // then
+        assertThat(availableResult.available).isEqualTo(true)
+        assertThat(unavailableResult.available).isEqualTo(false)
     }
 }


### PR DESCRIPTION
## 📚 개요
- #52 

## ✏️ 작업 내용
- 닉네임 중복 여부 검증 API 구현 (해당 기능이 필요함)
- 사용자 정보 수정 API validation 수정
  - 닉네임만 추가 입력받고 그 외 정보는 마이페이지에서 추가 입력되도록 유도한다고 하셔서 NotNull 제거 후 관련 로직 수정

## 💡 주의 사항
- 저번에 문서에 연령대 포맷 정보 추가해달라고 하셔서 해당 내용 추가
- 일부 네이밍 수정
