### PR TITLE
✨  커뮤니티 관련 엔티티 생성 (#55)

### DIFF
--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/domain/entity/CommunityCategoryEntity.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/domain/entity/CommunityCategoryEntity.kt
@@ -1,0 +1,19 @@
+package backend.team.ahachul_backend.api.community.domain.entity
+
+import backend.team.ahachul_backend.common.entity.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+
+@Entity
+class CommunityCategoryEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "community_category_id")
+    val id: Long? = null,
+
+    val name: String
+): BaseEntity() {
+}

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/domain/entity/CommunityCommentEntity.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/domain/entity/CommunityCommentEntity.kt
@@ -1,0 +1,21 @@
+package backend.team.ahachul_backend.api.community.domain.entity
+
+import backend.team.ahachul_backend.common.entity.BaseEntity
+import jakarta.persistence.*
+
+@Entity
+class CommunityCommentEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "community_comment_id")
+    val id: Long? = null,
+
+    var content: String,
+
+    @OneToOne(fetch = FetchType.LAZY)
+    var upperCommunityComment: CommunityCommentEntity?,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    var communityPost: CommunityPostEntity,
+): BaseEntity() {
+}

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/domain/entity/CommunityPostEntity.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/domain/entity/CommunityPostEntity.kt
@@ -1,0 +1,26 @@
+package backend.team.ahachul_backend.api.community.domain.entity
+
+import backend.team.ahachul_backend.common.domain.entity.RegionEntity
+import backend.team.ahachul_backend.common.entity.BaseEntity
+import jakarta.persistence.*
+
+@Entity
+class CommunityPostEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "community_post_id")
+    val id: Long? = null,
+
+    var title: String,
+
+    var content: String,
+
+    var views: Int,
+
+    @OneToOne(fetch = FetchType.LAZY)
+    var region: RegionEntity,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    var communityCategory: CommunityCategoryEntity
+): BaseEntity() {
+}

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/domain/entity/CommunityPostFileEntity.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/domain/entity/CommunityPostFileEntity.kt
@@ -1,0 +1,20 @@
+package backend.team.ahachul_backend.api.community.domain.entity
+
+import backend.team.ahachul_backend.common.domain.entity.FileEntity
+import backend.team.ahachul_backend.common.entity.BaseEntity
+import jakarta.persistence.*
+
+@Entity
+class CommunityPostFileEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "community_category_file_id")
+    val id: Long? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    var commentPost: CommunityPostEntity,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    var file: FileEntity
+): BaseEntity() {
+}

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/domain/entity/FileEntity.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/domain/entity/FileEntity.kt
@@ -1,0 +1,17 @@
+package backend.team.ahachul_backend.common.domain.entity
+
+import backend.team.ahachul_backend.common.entity.BaseEntity
+import jakarta.persistence.*
+
+@Entity
+class FileEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "file_id")
+    val id: Long? = null,
+
+    var fileName: String,
+
+    var filePath: String
+): BaseEntity() {
+}

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/domain/entity/RegionEntity.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/domain/entity/RegionEntity.kt
@@ -1,0 +1,15 @@
+package backend.team.ahachul_backend.common.domain.entity
+
+import backend.team.ahachul_backend.common.entity.BaseEntity
+import jakarta.persistence.*
+
+@Entity
+class RegionEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "region_id")
+    val id: Long? = null,
+
+    val name: String
+): BaseEntity() {
+}


### PR DESCRIPTION
## 📚 개요
- #55 

## ✏️ 작업 내용
- 커뮤니티 관련 엔티티 생성

## 💡 주의 사항
- 카테고리랑 지역 테이블에 type → name. enum으로 관리하려다가 그러면 테이블 만드는 의미가 없을 것 같아서 name으로 변경
- 좋아요는 설계는 되어있지만, 다음 스프린트에 할 거라 제외
- 커뮤니티 게시글 테이블에 지역 테이블 1:1로 연결
