### PR TITLE
:sparkles: Add Authorization Header Prefix 'Bearer' (#66)

### DIFF
--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/interceptor/AuthenticationInterceptor.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/interceptor/AuthenticationInterceptor.kt
@@ -20,13 +20,22 @@ class AuthenticationInterceptor(
         private val jwtUtils: JwtUtils
 ): HandlerInterceptor {
 
+    companion object {
+        const val AUTH_PREFIX = "Bearer "
+    }
+
     override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
         if (handler !is HandlerMethod) return true
         handler.getMethodAnnotation(Authentication::class.java) ?: return true
 
         try {
             val jwtToken = request.getHeader("Authorization")
-            val verifiedJwtToken = jwtUtils.verify(jwtToken)
+
+            if (!jwtToken.startsWith(AUTH_PREFIX)) throw UnsupportedJwtException("not supported jwt")
+
+            val jwtTokenExcludePrefix = jwtToken.substring(AUTH_PREFIX.length)
+
+            val verifiedJwtToken = jwtUtils.verify(jwtTokenExcludePrefix)
 
             RequestUtils.setAttribute("memberId", verifiedJwtToken.body.subject)
 

--- a/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/CommunityCommentControllerDocsTest.kt
+++ b/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/CommunityCommentControllerDocsTest.kt
@@ -97,7 +97,7 @@ class CommunityCommentControllerDocsTest : CommonDocsConfig() {
         // when
         val result = mockMvc.perform(
             post("/v1/community/comments")
-                .header("Authorization", "<Access Token>")
+                .header("Authorization", "Bearer <Access Token>")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
                 .accept(MediaType.APPLICATION_JSON)
@@ -146,7 +146,7 @@ class CommunityCommentControllerDocsTest : CommonDocsConfig() {
         // when
         val result = mockMvc.perform(
             patch("/v1/community/comments/{commentId}", 1)
-                .header("Authorization", "<Access Token>")
+                .header("Authorization", "Bearer <Access Token>")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
                 .accept(MediaType.APPLICATION_JSON)
@@ -190,7 +190,7 @@ class CommunityCommentControllerDocsTest : CommonDocsConfig() {
         // when
         val result = mockMvc.perform(
             delete("/v1/community/comments/{commentId}", 1)
-                .header("Authorization", "<Access Token>")
+                .header("Authorization", "Bearer <Access Token>")
                 .accept(MediaType.APPLICATION_JSON)
         )
 

--- a/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/CommunityPostControllerDocsTest.kt
+++ b/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/CommunityPostControllerDocsTest.kt
@@ -165,7 +165,7 @@ class CommunityPostControllerDocsTest : CommonDocsConfig() {
         // when
         val result = mockMvc.perform(
             post("/v1/community/posts")
-                .header("Authorization", "<Access Token>")
+                .header("Authorization", "Bearer <Access Token>")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
                 .accept(MediaType.APPLICATION_JSON)
@@ -220,7 +220,7 @@ class CommunityPostControllerDocsTest : CommonDocsConfig() {
         // when
         val result = mockMvc.perform(
             patch("/v1/community/posts/{postId}", 1)
-                .header("Authorization", "<Access Token>")
+                .header("Authorization", "Bearer <Access Token>")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
                 .accept(MediaType.APPLICATION_JSON)
@@ -268,7 +268,7 @@ class CommunityPostControllerDocsTest : CommonDocsConfig() {
         // when
         val result = mockMvc.perform(
             delete("/v1/community/posts/{postId}", 1)
-                .header("Authorization", "<Access Token>")
+                .header("Authorization", "Bearer <Access Token>")
                 .accept(MediaType.APPLICATION_JSON)
         )
 

--- a/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/lost/adapter/web/in/LostPostControllerDocsTest.kt
+++ b/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/lost/adapter/web/in/LostPostControllerDocsTest.kt
@@ -146,7 +146,7 @@ class LostPostControllerDocsTest: CommonDocsConfig() {
         // when
         val result = mockMvc.perform(
             post("/v1/lost/posts")
-                .header("Authorization", "<Access Token>")
+                .header("Authorization", "Bearer <Access Token>")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
                 .accept(MediaType.APPLICATION_JSON)
@@ -193,7 +193,7 @@ class LostPostControllerDocsTest: CommonDocsConfig() {
         // when
         val result = mockMvc.perform(
             patch("/v1/lost/posts/{lostId}", 1)
-                .header("Authorization", "<Access Token>")
+                .header("Authorization", "Bearer <Access Token>")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
                 .accept(MediaType.APPLICATION_JSON)
@@ -234,7 +234,7 @@ class LostPostControllerDocsTest: CommonDocsConfig() {
         // when
         val result = mockMvc.perform(
             delete("/v1/lost/posts/{lostId}", 1)
-                .header("Authorization", "<Access Token>")
+                .header("Authorization", "Bearer <Access Token>")
                 .accept(MediaType.APPLICATION_JSON)
         )
 

--- a/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/MemberControllerDocsTest.kt
+++ b/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/MemberControllerDocsTest.kt
@@ -43,7 +43,7 @@ class MemberControllerDocsTest : CommonDocsConfig() {
         // when
         val result = mockMvc.perform(
             get("/v1/members")
-                .header("Authorization", "<Access Token>")
+                .header("Authorization", "Bearer <Access Token>")
                 .accept(MediaType.APPLICATION_JSON)
         )
 
@@ -90,7 +90,7 @@ class MemberControllerDocsTest : CommonDocsConfig() {
         // when
         val result = mockMvc.perform(
             patch("/v1/members")
-                .header("Authorization", "<Access Token>")
+                .header("Authorization", "Bearer <Access Token>")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
                 .accept(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
## 📚 개요
- #66 

## ✏️ 작업 내용
- Add Authorization Header Prefix 'Bearer'

## 💡 주의 사항
- 인증 토큰에 prefix 빼먹어서 추가했습니다.
- 확인 후에 이상한 점 없으면 머지해주세요.
