### PR TITLE
♻️ 패키지 이동 및 네이밍 통일 (#83)

### DIFF
--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/CommunityCommentController.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/CommunityCommentController.kt
@@ -1,9 +1,9 @@
 package backend.team.ahachul_backend.api.community.adapter.web.`in`
 
-import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.CreateCommunityCommentDto
-import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.DeleteCommunityCommentDto
-import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.GetCommunityCommentsDto
-import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.UpdateCommunityCommentDto
+import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.comment.CreateCommunityCommentDto
+import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.comment.DeleteCommunityCommentDto
+import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.comment.GetCommunityCommentsDto
+import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.comment.UpdateCommunityCommentDto
 import backend.team.ahachul_backend.api.community.application.port.`in`.CommunityCommentUseCase
 import backend.team.ahachul_backend.common.annotation.Authentication
 import backend.team.ahachul_backend.common.response.CommonResponse

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/CommunityPostController.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/CommunityPostController.kt
@@ -1,7 +1,7 @@
 package backend.team.ahachul_backend.api.community.adapter.web.`in`
 
 import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.*
-import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.posts.*
+import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.post.*
 import backend.team.ahachul_backend.api.community.application.port.`in`.CommunityPostUseCase
 import backend.team.ahachul_backend.common.annotation.Authentication
 import backend.team.ahachul_backend.common.response.CommonResponse

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/DeleteCommunityCommentDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/DeleteCommunityCommentDto.kt
@@ -1,8 +1,0 @@
-package backend.team.ahachul_backend.api.community.adapter.web.`in`.dto
-
-class DeleteCommunityCommentDto {
-
-    data class Response(
-        val id: Long,
-    )
-}

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/comment/CreateCommunityCommentDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/comment/CreateCommunityCommentDto.kt
@@ -1,4 +1,4 @@
-package backend.team.ahachul_backend.api.community.adapter.web.`in`.dto
+package backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.comment
 
 class CreateCommunityCommentDto {
 

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/comment/DeleteCommunityCommentDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/comment/DeleteCommunityCommentDto.kt
@@ -1,0 +1,1 @@
+package backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.comment

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/comment/GetCommunityCommentsDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/comment/GetCommunityCommentsDto.kt
@@ -1,4 +1,4 @@
-package backend.team.ahachul_backend.api.community.adapter.web.`in`.dto
+package backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.comment
 
 import java.time.LocalDateTime
 

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/comment/UpdateCommunityCommentDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/comment/UpdateCommunityCommentDto.kt
@@ -1,4 +1,4 @@
-package backend.team.ahachul_backend.api.community.adapter.web.`in`.dto
+package backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.comment
 
 class UpdateCommunityCommentDto {
 

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/post/CreateCommunityPostCommand.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/post/CreateCommunityPostCommand.kt
@@ -1,9 +1,8 @@
-package backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.posts
+package backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.post
 
 import backend.team.ahachul_backend.api.community.domain.model.CommunityCategoryType
 
-class UpdateCommunityPostCommand(
-    val id: Long,
+class CreateCommunityPostCommand(
     val title: String,
     val content: String,
     val categoryType: CommunityCategoryType,

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/post/CreateCommunityPostDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/post/CreateCommunityPostDto.kt
@@ -1,18 +1,18 @@
-package backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.posts
+package backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.post
 
 import backend.team.ahachul_backend.api.community.domain.entity.CommunityPostEntity
 import backend.team.ahachul_backend.api.community.domain.model.CommunityCategoryType
+import backend.team.ahachul_backend.common.model.RegionType
 
-class UpdateCommunityPostDto {
+class CreateCommunityPostDto {
 
     data class Request(
         val title: String,
         val content: String,
         val categoryType: CommunityCategoryType,
     ) {
-        fun toCommand(postId: Long): UpdateCommunityPostCommand {
-            return UpdateCommunityPostCommand(
-                id = postId,
+        fun toCommand(): CreateCommunityPostCommand {
+            return CreateCommunityPostCommand(
                 title = title,
                 content = content,
                 categoryType = categoryType
@@ -25,6 +25,7 @@ class UpdateCommunityPostDto {
         val title: String,
         val content: String,
         val categoryType: CommunityCategoryType,
+        val region: RegionType,
     ) {
         companion object {
             fun from(entity: CommunityPostEntity): Response {
@@ -32,7 +33,8 @@ class UpdateCommunityPostDto {
                     id = entity.id,
                     title = entity.title,
                     content = entity.content,
-                    categoryType = entity.categoryType
+                    categoryType = entity.categoryType,
+                    region = entity.regionType
                 )
             }
         }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/post/DeleteCommunityPostCommand.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/post/DeleteCommunityPostCommand.kt
@@ -1,0 +1,6 @@
+package backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.post
+
+class DeleteCommunityPostCommand(
+    val id: Long,
+) {
+}

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/post/DeleteCommunityPostDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/post/DeleteCommunityPostDto.kt
@@ -1,4 +1,4 @@
-package backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.posts
+package backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.post
 
 class DeleteCommunityPostDto {
 

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/post/GetCommunityPostCommand.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/post/GetCommunityPostCommand.kt
@@ -1,0 +1,6 @@
+package backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.post
+
+class GetCommunityPostCommand(
+    val id: Long,
+) {
+}

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/post/GetCommunityPostDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/post/GetCommunityPostDto.kt
@@ -1,25 +1,14 @@
-package backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.posts
+package backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.post
 
 import backend.team.ahachul_backend.api.community.domain.model.CommunityCategoryType
 import java.time.LocalDateTime
 
-class SearchCommunityPostDto {
-
-    data class Request(
-        val categoryType: CommunityCategoryType?,
-        val subwayLine: String?,
-        val title: String?,
-        val content: String?,
-        val hashTag: String?
-    )
+class GetCommunityPostDto {
 
     data class Response(
-        val posts: List<CommunityPost>
-    )
-
-    data class CommunityPost(
         val id: Long,
         val title: String,
+        val content: String,
         val categoryType: CommunityCategoryType,
         val views: Int,
         val likes: Int,

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/post/SearchCommunityPostDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/post/SearchCommunityPostDto.kt
@@ -1,14 +1,25 @@
-package backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.posts
+package backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.post
 
 import backend.team.ahachul_backend.api.community.domain.model.CommunityCategoryType
 import java.time.LocalDateTime
 
-class GetCommunityPostDto {
+class SearchCommunityPostDto {
+
+    data class Request(
+        val categoryType: CommunityCategoryType?,
+        val subwayLine: String?,
+        val title: String?,
+        val content: String?,
+        val hashTag: String?
+    )
 
     data class Response(
+        val posts: List<CommunityPost>
+    )
+
+    data class CommunityPost(
         val id: Long,
         val title: String,
-        val content: String,
         val categoryType: CommunityCategoryType,
         val views: Int,
         val likes: Int,

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/post/UpdateCommunityPostCommand.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/post/UpdateCommunityPostCommand.kt
@@ -1,8 +1,9 @@
-package backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.posts
+package backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.post
 
 import backend.team.ahachul_backend.api.community.domain.model.CommunityCategoryType
 
-class CreateCommunityPostCommand(
+class UpdateCommunityPostCommand(
+    val id: Long,
     val title: String,
     val content: String,
     val categoryType: CommunityCategoryType,

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/post/UpdateCommunityPostDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/post/UpdateCommunityPostDto.kt
@@ -1,18 +1,18 @@
-package backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.posts
+package backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.post
 
 import backend.team.ahachul_backend.api.community.domain.entity.CommunityPostEntity
 import backend.team.ahachul_backend.api.community.domain.model.CommunityCategoryType
-import backend.team.ahachul_backend.common.model.RegionType
 
-class CreateCommunityPostDto {
+class UpdateCommunityPostDto {
 
     data class Request(
         val title: String,
         val content: String,
         val categoryType: CommunityCategoryType,
     ) {
-        fun toCommand(): CreateCommunityPostCommand {
-            return CreateCommunityPostCommand(
+        fun toCommand(postId: Long): UpdateCommunityPostCommand {
+            return UpdateCommunityPostCommand(
+                id = postId,
                 title = title,
                 content = content,
                 categoryType = categoryType
@@ -25,7 +25,6 @@ class CreateCommunityPostDto {
         val title: String,
         val content: String,
         val categoryType: CommunityCategoryType,
-        val region: RegionType,
     ) {
         companion object {
             fun from(entity: CommunityPostEntity): Response {
@@ -33,8 +32,7 @@ class CreateCommunityPostDto {
                     id = entity.id,
                     title = entity.title,
                     content = entity.content,
-                    categoryType = entity.categoryType,
-                    region = entity.regionType
+                    categoryType = entity.categoryType
                 )
             }
         }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/posts/DeleteCommunityPostCommand.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/posts/DeleteCommunityPostCommand.kt
@@ -1,6 +1,0 @@
-package backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.posts
-
-class DeleteCommunityPostCommand(
-    val id: Long,
-) {
-}

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/posts/GetCommunityPostCommand.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/posts/GetCommunityPostCommand.kt
@@ -1,6 +1,0 @@
-package backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.posts
-
-class GetCommunityPostCommand(
-    val id: Long,
-) {
-}

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/application/port/in/CommunityCommentUseCase.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/application/port/in/CommunityCommentUseCase.kt
@@ -1,6 +1,9 @@
 package backend.team.ahachul_backend.api.community.application.port.`in`
 
-import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.*
+import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.comment.CreateCommunityCommentDto
+import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.comment.DeleteCommunityCommentDto
+import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.comment.GetCommunityCommentsDto
+import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.comment.UpdateCommunityCommentDto
 
 interface CommunityCommentUseCase {
 

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/application/port/in/CommunityPostUseCase.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/application/port/in/CommunityPostUseCase.kt
@@ -1,6 +1,6 @@
 package backend.team.ahachul_backend.api.community.application.port.`in`
 
-import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.posts.*
+import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.post.*
 
 interface CommunityPostUseCase {
 

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/application/service/CommunityCommentService.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/application/service/CommunityCommentService.kt
@@ -1,9 +1,9 @@
 package backend.team.ahachul_backend.api.community.application.service
 
-import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.CreateCommunityCommentDto
-import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.DeleteCommunityCommentDto
-import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.GetCommunityCommentsDto
-import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.UpdateCommunityCommentDto
+import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.comment.CreateCommunityCommentDto
+import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.comment.DeleteCommunityCommentDto
+import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.comment.GetCommunityCommentsDto
+import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.comment.UpdateCommunityCommentDto
 import backend.team.ahachul_backend.api.community.application.port.`in`.CommunityCommentUseCase
 import org.springframework.stereotype.Service
 

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/application/service/CommunityPostService.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/application/service/CommunityPostService.kt
@@ -1,6 +1,6 @@
 package backend.team.ahachul_backend.api.community.application.service
 
-import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.posts.*
+import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.post.*
 import backend.team.ahachul_backend.api.community.application.port.`in`.CommunityPostUseCase
 import backend.team.ahachul_backend.api.community.application.port.out.CommunityPostReader
 import backend.team.ahachul_backend.api.community.application.port.out.CommunityPostWriter

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/domain/entity/CommunityPostEntity.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/domain/entity/CommunityPostEntity.kt
@@ -1,11 +1,11 @@
 package backend.team.ahachul_backend.api.community.domain.entity
 
-import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.posts.CreateCommunityPostCommand
-import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.posts.UpdateCommunityPostCommand
+import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.post.CreateCommunityPostCommand
+import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.post.UpdateCommunityPostCommand
 import backend.team.ahachul_backend.api.community.domain.model.CommunityCategoryType
 import backend.team.ahachul_backend.api.member.domain.entity.MemberEntity
 import backend.team.ahachul_backend.common.entity.BaseEntity
-import backend.team.ahachul_backend.common.model.CommunityPostType
+import backend.team.ahachul_backend.api.community.domain.model.CommunityPostType
 import backend.team.ahachul_backend.common.model.RegionType
 import jakarta.persistence.*
 
@@ -32,7 +32,7 @@ class CommunityPostEntity(
     @ManyToOne(fetch = FetchType.LAZY)
     var member: MemberEntity? = null,
 
-): BaseEntity() {
+    ): BaseEntity() {
 
     companion object {
         fun of(command: CreateCommunityPostCommand, memberEntity: MemberEntity): CommunityPostEntity {

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/domain/model/CommunityPostType.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/domain/model/CommunityPostType.kt
@@ -1,0 +1,5 @@
+package backend.team.ahachul_backend.api.community.domain.model
+
+enum class CommunityPostType {
+    CREATED, DELETED
+}

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/domain/entity/MemberEntity.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/domain/entity/MemberEntity.kt
@@ -4,7 +4,7 @@ import backend.team.ahachul_backend.api.member.application.port.`in`.command.Log
 import backend.team.ahachul_backend.api.member.domain.model.GenderType
 import backend.team.ahachul_backend.api.member.domain.model.ProviderType
 
-import backend.team.ahachul_backend.api.member.domain.model.MemberStatus
+import backend.team.ahachul_backend.api.member.domain.model.MemberStatusType
 import backend.team.ahachul_backend.common.dto.GoogleUserInfoDto
 import backend.team.ahachul_backend.common.dto.KakaoMemberInfoDto
 import backend.team.ahachul_backend.common.entity.BaseEntity
@@ -32,7 +32,7 @@ class MemberEntity(
         var ageRange: String?,
 
         @Enumerated(EnumType.STRING)
-        var status: MemberStatus
+        var status: MemberStatusType
 ): BaseEntity() {
 
         companion object {
@@ -44,7 +44,7 @@ class MemberEntity(
                                 email = userInfo.kakaoAccount.email,
                                 gender = userInfo.kakaoAccount.gender?.let { GenderType.of(it) },
                                 ageRange = userInfo.kakaoAccount.ageRange?.let { it.split("~")[0] },
-                                status = MemberStatus.ACTIVE
+                                status = MemberStatusType.ACTIVE
                         )
                 }
 
@@ -56,7 +56,7 @@ class MemberEntity(
                                 email = userInfo.email,
                                 gender = null,
                                 ageRange = null,
-                                status = MemberStatus.ACTIVE
+                                status = MemberStatusType.ACTIVE
                         )
                 }
         }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/domain/model/MemberStatusType.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/domain/model/MemberStatusType.kt
@@ -1,5 +1,5 @@
 package backend.team.ahachul_backend.api.member.domain.model
 
-enum class MemberStatus {
+enum class MemberStatusType {
     ACTIVE, SUSPENDED, DELETE
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/model/CommunityPostType.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/model/CommunityPostType.kt
@@ -1,5 +1,0 @@
-package backend.team.ahachul_backend.common.model
-
-enum class CommunityPostType {
-    CREATED, DELETED
-}

--- a/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/CommunityCommentControllerDocsTest.kt
+++ b/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/CommunityCommentControllerDocsTest.kt
@@ -1,9 +1,9 @@
 package backend.team.ahachul_backend.api.community.adapter.web.`in`
 
-import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.CreateCommunityCommentDto
-import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.DeleteCommunityCommentDto
-import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.GetCommunityCommentsDto
-import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.UpdateCommunityCommentDto
+import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.comment.CreateCommunityCommentDto
+import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.comment.DeleteCommunityCommentDto
+import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.comment.GetCommunityCommentsDto
+import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.comment.UpdateCommunityCommentDto
 import backend.team.ahachul_backend.api.community.application.port.`in`.CommunityCommentUseCase
 import backend.team.ahachul_backend.config.controller.CommonDocsConfig
 import org.junit.jupiter.api.Test

--- a/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/CommunityPostControllerDocsTest.kt
+++ b/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/CommunityPostControllerDocsTest.kt
@@ -1,7 +1,7 @@
 package backend.team.ahachul_backend.api.community.adapter.web.`in`
 
 import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.*
-import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.posts.*
+import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.post.*
 import backend.team.ahachul_backend.api.community.application.port.`in`.CommunityPostUseCase
 import backend.team.ahachul_backend.api.community.domain.model.CommunityCategoryType
 import backend.team.ahachul_backend.common.model.RegionType

--- a/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/community/application/service/CommunityPostServiceTest.kt
+++ b/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/community/application/service/CommunityPostServiceTest.kt
@@ -1,18 +1,18 @@
 package backend.team.ahachul_backend.api.community.application.service
 
-import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.posts.CreateCommunityPostCommand
-import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.posts.DeleteCommunityPostCommand
-import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.posts.UpdateCommunityPostCommand
+import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.post.CreateCommunityPostCommand
+import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.post.DeleteCommunityPostCommand
+import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.post.UpdateCommunityPostCommand
 import backend.team.ahachul_backend.api.community.adapter.web.out.CommunityPostRepository
 import backend.team.ahachul_backend.api.community.application.port.`in`.CommunityPostUseCase
 import backend.team.ahachul_backend.api.community.domain.model.CommunityCategoryType
 import backend.team.ahachul_backend.api.member.adapter.web.out.MemberRepository
 import backend.team.ahachul_backend.api.member.domain.entity.MemberEntity
 import backend.team.ahachul_backend.api.member.domain.model.GenderType
-import backend.team.ahachul_backend.api.member.domain.model.MemberStatus
+import backend.team.ahachul_backend.api.member.domain.model.MemberStatusType
 import backend.team.ahachul_backend.api.member.domain.model.ProviderType
 import backend.team.ahachul_backend.common.exception.CommonException
-import backend.team.ahachul_backend.common.model.CommunityPostType
+import backend.team.ahachul_backend.api.community.domain.model.CommunityPostType
 import backend.team.ahachul_backend.common.model.RegionType
 import backend.team.ahachul_backend.common.utils.RequestUtils
 import jakarta.transaction.Transactional
@@ -45,7 +45,7 @@ class CommunityPostServiceTest(
             email = "email",
             gender = GenderType.MALE,
             ageRange = "20",
-            status = MemberStatus.ACTIVE
+            status = MemberStatusType.ACTIVE
             )
         )
         member!!.id?.let { RequestUtils.setAttribute("memberId", it) }

--- a/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/member/application/service/MemberServiceTest.kt
+++ b/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/member/application/service/MemberServiceTest.kt
@@ -6,7 +6,7 @@ import backend.team.ahachul_backend.api.member.application.port.`in`.command.Che
 import backend.team.ahachul_backend.api.member.application.port.`in`.command.UpdateMemberCommand
 import backend.team.ahachul_backend.api.member.domain.entity.MemberEntity
 import backend.team.ahachul_backend.api.member.domain.model.GenderType
-import backend.team.ahachul_backend.api.member.domain.model.MemberStatus
+import backend.team.ahachul_backend.api.member.domain.model.MemberStatusType
 import backend.team.ahachul_backend.api.member.domain.model.ProviderType
 import backend.team.ahachul_backend.common.utils.RequestUtils
 import org.assertj.core.api.Assertions.assertThat
@@ -34,7 +34,7 @@ class MemberServiceTest(
                 email = "email",
                 gender = GenderType.MALE,
                 ageRange = "20",
-                status = MemberStatus.ACTIVE
+                status = MemberStatusType.ACTIVE
         ))
         member.id?.let { RequestUtils.setAttribute("memberId", it) }
     }


### PR DESCRIPTION
## 📚 개요
- #83 

## ✏️ 작업 내용
- Enum 은 접미사 Type으로 통일 - MemberStatus -> MemberStatusType
- common.model 에 있던 CommunityPostType domain.model 로 이동
- community - comment, post dto 패키지 분리

## 💡 주의 사항
- dto 파일이 너무 많아져서 패키지로 분리해 놓았는데 생각해 보니 코틀린은 클래스 하나당 파일 하나를 강제하고 있지 않아서 한 파일 안에 같은 성질의 클래스들을 모아 넣는 방식으로 리팩토링 진행해도 될 것 같음.
