### PR TITLE
✨ S3, Redis 의존성 설정, 유틸 클래스 구현 (#88)

### DIFF
--- a/ahachul_backend/build.gradle.kts
+++ b/ahachul_backend/build.gradle.kts
@@ -59,6 +59,9 @@ dependencies {
     // https://mvnrepository.com/artifact/com.h2database/h2
     runtimeOnly("com.h2database:h2:2.1.214")
 
+    // https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-starter-aws
+    implementation("org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE")
+
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     runtimeOnly("com.mysql:mysql-connector-j")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
@@ -101,7 +104,7 @@ tasks {
 
 tasks.register<Copy>("copySecret") {
     from("./ahachul_secret") {
-        exclude("application.yml")
+//        exclude("application.yml")
     }
     into("./src/main/resources")
 }

--- a/ahachul_backend/build.gradle.kts
+++ b/ahachul_backend/build.gradle.kts
@@ -62,6 +62,8 @@ dependencies {
     // https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-starter-aws
     implementation("org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE")
 
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
+
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     runtimeOnly("com.mysql:mysql-connector-j")
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/ahachul_backend/build.gradle.kts
+++ b/ahachul_backend/build.gradle.kts
@@ -106,7 +106,7 @@ tasks {
 
 tasks.register<Copy>("copySecret") {
     from("./ahachul_secret") {
-//        exclude("application.yml")
+        exclude("application.yml")
     }
     into("./src/main/resources")
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/AwsS3Client.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/AwsS3Client.kt
@@ -5,6 +5,7 @@ import backend.team.ahachul_backend.common.logging.Logger
 import backend.team.ahachul_backend.common.properties.AwsS3Properties
 import backend.team.ahachul_backend.common.response.ResponseCode
 import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.model.CannedAccessControlList
 import com.amazonaws.services.s3.model.PutObjectRequest
 import mu.KotlinLogging
 import org.springframework.stereotype.Component
@@ -28,7 +29,7 @@ class AwsS3Client(
                     s3Properties.bucketName,
                     generateRandomUUID(),
                     convertToFile(file)
-                )
+                ).withCannedAcl(CannedAccessControlList.PublicRead)
             )
         } catch (e: CommonException) {
             logger.error(e.message, ResponseCode.BAD_REQUEST, e.stackTraceToString())

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/AwsS3Client.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/AwsS3Client.kt
@@ -1,8 +1,12 @@
 package backend.team.ahachul_backend.common.client
 
+import backend.team.ahachul_backend.common.exception.CommonException
+import backend.team.ahachul_backend.common.logging.Logger
 import backend.team.ahachul_backend.common.properties.AwsS3Properties
+import backend.team.ahachul_backend.common.response.ResponseCode
 import com.amazonaws.services.s3.AmazonS3Client
 import com.amazonaws.services.s3.model.PutObjectRequest
+import mu.KotlinLogging
 import org.springframework.stereotype.Component
 import org.springframework.web.multipart.MultipartFile
 import java.io.File
@@ -15,14 +19,24 @@ class AwsS3Client(
     private val s3Properties: AwsS3Properties
 ) {
 
+    val logger: Logger = Logger(javaClass)
+
     fun upload(file: MultipartFile) {
-        s3Client.putObject(
-            PutObjectRequest(
-                s3Properties.bucketName,
-                generateRandomUUID(),
-                convertToFile(file)
+        try {
+            s3Client.putObject(
+                PutObjectRequest(
+                    s3Properties.bucketName,
+                    generateRandomUUID(),
+                    convertToFile(file)
+                )
             )
-        )
+        } catch (e: CommonException) {
+            logger.error(e.message, ResponseCode.BAD_REQUEST, e.stackTraceToString())
+        }
+    }
+
+    fun upload(files: List<MultipartFile>) {
+        files.forEach { upload(it) }
     }
 
     private fun generateRandomUUID(): String {
@@ -30,11 +44,12 @@ class AwsS3Client(
     }
 
     private fun convertToFile(multipartFile: MultipartFile): File {
-        val file = File(multipartFile.originalFilename!!)
-        file.createNewFile()
-        val fos = FileOutputStream(file)
-        fos.write(multipartFile.bytes)
-        fos.close()
-        return file
+        val tempFile = File.createTempFile(multipartFile.originalFilename!!, "")
+        multipartFile.inputStream.use { input ->
+            tempFile.outputStream().use { output ->
+                input.copyTo(output)
+            }
+        }
+        return tempFile
     }
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/AwsS3Client.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/AwsS3Client.kt
@@ -1,0 +1,40 @@
+package backend.team.ahachul_backend.common.client
+
+import backend.team.ahachul_backend.common.properties.AwsS3Properties
+import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.model.PutObjectRequest
+import org.springframework.stereotype.Component
+import org.springframework.web.multipart.MultipartFile
+import java.io.File
+import java.io.FileOutputStream
+import java.util.UUID
+
+@Component
+class AwsS3Client(
+    private val s3Client: AmazonS3Client,
+    private val s3Properties: AwsS3Properties
+) {
+
+    fun upload(file: MultipartFile) {
+        s3Client.putObject(
+            PutObjectRequest(
+                s3Properties.bucketName,
+                generateRandomUUID(),
+                convertToFile(file)
+            )
+        )
+    }
+
+    private fun generateRandomUUID(): String {
+        return UUID.randomUUID().toString()
+    }
+
+    private fun convertToFile(multipartFile: MultipartFile): File {
+        val file = File(multipartFile.originalFilename!!)
+        file.createNewFile()
+        val fos = FileOutputStream(file)
+        fos.write(multipartFile.bytes)
+        fos.close()
+        return file
+    }
+}

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/RedisClient.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/RedisClient.kt
@@ -1,0 +1,27 @@
+package backend.team.ahachul_backend.common.client
+
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Component
+import java.util.concurrent.TimeUnit
+
+@Component
+class RedisClient(
+    private val redisTemplate: RedisTemplate<String, Any>
+) {
+
+    fun set(key: String, value: Any) {
+        redisTemplate.opsForValue().set(key, value)
+    }
+
+    fun set(key: String, value: Any, timeout: Long, timeUnit: TimeUnit) {
+        redisTemplate.opsForValue().set(key, value, timeout, timeUnit)
+    }
+
+    fun get(key: String): Any? {
+        return redisTemplate.opsForValue().get(key)
+    }
+
+    fun delete(key: String) {
+        redisTemplate.delete(key)
+    }
+}

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/config/AwsS3Config.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/config/AwsS3Config.kt
@@ -1,0 +1,24 @@
+package backend.team.ahachul_backend.common.config
+
+import backend.team.ahachul_backend.common.properties.AwsS3Properties
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class AwsS3Config(
+    private val awsS3Properties: AwsS3Properties
+) {
+
+    @Bean
+    fun amazonS3Client(): AmazonS3Client {
+        val credentials = BasicAWSCredentials(awsS3Properties.accessKey, awsS3Properties.secretKey)
+        return AmazonS3ClientBuilder.standard()
+            .withRegion(awsS3Properties.region)
+            .withCredentials(AWSStaticCredentialsProvider(credentials))
+            .build() as AmazonS3Client
+    }
+}

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/config/RedisConfig.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/config/RedisConfig.kt
@@ -1,0 +1,31 @@
+package backend.team.ahachul_backend.common.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.serializer.StringRedisSerializer
+
+@Configuration
+class RedisConfig {
+
+    @Bean
+    fun redisConnectionFactory(): RedisConnectionFactory = LettuceConnectionFactory(RedisStandaloneConfiguration())
+
+    @Bean
+    fun redisTemplate(): RedisTemplate<String, Any> {
+        val redisTemplate = RedisTemplate<String, Any>()
+
+        redisTemplate.keySerializer = StringRedisSerializer()
+        redisTemplate.valueSerializer = StringRedisSerializer()
+
+        redisTemplate.hashKeySerializer = StringRedisSerializer()
+        redisTemplate.hashValueSerializer = StringRedisSerializer()
+
+        redisTemplate.setConnectionFactory(redisConnectionFactory())
+
+        return redisTemplate
+    }
+}

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/config/RedisConfig.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/config/RedisConfig.kt
@@ -1,5 +1,6 @@
 package backend.team.ahachul_backend.common.config
 
+import backend.team.ahachul_backend.common.properties.RedisProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.redis.connection.RedisConnectionFactory
@@ -9,10 +10,16 @@ import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.data.redis.serializer.StringRedisSerializer
 
 @Configuration
-class RedisConfig {
+class RedisConfig(
+    private val redisProperties: RedisProperties,
+) {
 
     @Bean
-    fun redisConnectionFactory(): RedisConnectionFactory = LettuceConnectionFactory(RedisStandaloneConfiguration())
+    fun redisConnectionFactory(): RedisConnectionFactory =
+        LettuceConnectionFactory(RedisStandaloneConfiguration(
+            redisProperties.host,
+            redisProperties.port
+        ))
 
     @Bean
     fun redisTemplate(): RedisTemplate<String, Any> {

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/properties/AwsS3Properties.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/properties/AwsS3Properties.kt
@@ -1,0 +1,14 @@
+package backend.team.ahachul_backend.common.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ConfigurationProperties(prefix = "cloud.aws.credentials")
+class AwsS3Properties(
+    var accessKey: String = "",
+    var secretKey: String = "",
+    var bucketName: String = "",
+    var region: String = ""
+) {
+}

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/properties/RedisProperties.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/properties/RedisProperties.kt
@@ -1,0 +1,12 @@
+package backend.team.ahachul_backend.common.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ConfigurationProperties(prefix = "spring.data.redis")
+class RedisProperties(
+    var host: String = "localhost",
+    var port: Int = 6379,
+) {
+}

--- a/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/common/client/RedisClientTest.kt
+++ b/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/common/client/RedisClientTest.kt
@@ -1,0 +1,24 @@
+package backend.team.ahachul_backend.common.client
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+class RedisClientTest(
+    @Autowired val redisClient: RedisClient
+) {
+
+    @Test
+    @DisplayName("레디스 기본동작 테스트")
+    fun 레디스_기본동작_테스트() {
+        val test = "TEST"
+        redisClient.set(test, test)
+        assertThat(redisClient.get(test)).isEqualTo(test)
+        redisClient.delete(test)
+        assertThat(redisClient.get(test)).isNull()
+    }
+}


### PR DESCRIPTION
## 📚 개요
- #88 

## ✏️ 작업 내용
- S3 환경 세팅
- Redis 환경 세팅

## 💡 주의 사항
- 아래 순으로 진행해주시면 될 것 같아요.
- s3, elasticache 인프라 구축
- yml 파일 수정. 포맷을 추가해 두었습니다.
```yml
spring:
  data:
    redis:
      host: "<string>"
      port: 6379
cloud:
  aws:
    credentials:
      access-key: "<string>"
      secret-key: "<string>"
      bucket-name: "<string>"
      region: "<string>"
```
- 테스트 코드 실행
