### PR TITLE
✨ 커뮤니티 코멘트 조회 포맷 형식 변경 (#104)

### DIFF
--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/comment/GetCommunityCommentsDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/comment/GetCommunityCommentsDto.kt
@@ -1,17 +1,24 @@
 package backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.comment
 
+import backend.team.ahachul_backend.api.community.domain.model.CommunityCommentType
 import java.time.LocalDateTime
 
 class GetCommunityCommentsDto {
 
     data class Response(
-        val comments: List<CommunityComment>
+        val comments: List<CommunityCommentList>
+    )
+
+    data class CommunityCommentList(
+        val parentComment: CommunityComment,
+        val childComments: List<CommunityComment>
     )
 
     data class CommunityComment(
         val id: Long,
         val upperCommentId: Long?,
         val content: String,
+        val status: CommunityCommentType,
         val createdAt: LocalDateTime,
         val createdBy: String,
         val writer: String,

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/out/CommunityCommentRepository.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/out/CommunityCommentRepository.kt
@@ -6,6 +6,10 @@ import org.springframework.data.jpa.repository.Query
 
 interface CommunityCommentRepository: JpaRepository<CommunityCommentEntity, Long> {
 
-    @Query("SELECT cc FROM CommunityCommentEntity cc JOIN FETCH cc.member m WHERE cc.communityPost.id = :postId")
+    @Query("SELECT cc " +
+            "FROM CommunityCommentEntity cc " +
+            "JOIN FETCH cc.member m " +
+            "WHERE cc.communityPost.id = :postId " +
+            "ORDER BY cc.createdAt ASC")
     fun findAllByCommunityPostId(postId: Long): List<CommunityCommentEntity>
 }

--- a/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/CommunityCommentControllerDocsTestTest.kt
+++ b/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/CommunityCommentControllerDocsTestTest.kt
@@ -5,6 +5,7 @@ import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.comment.D
 import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.comment.GetCommunityCommentsDto
 import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.comment.UpdateCommunityCommentDto
 import backend.team.ahachul_backend.api.community.application.port.`in`.CommunityCommentUseCase
+import backend.team.ahachul_backend.api.community.domain.model.CommunityCommentType
 import backend.team.ahachul_backend.config.controller.CommonDocsTestConfig
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
@@ -17,6 +18,7 @@ import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*
 import org.springframework.restdocs.payload.JsonFieldType
 import org.springframework.restdocs.payload.PayloadDocumentation
+import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
 import org.springframework.restdocs.request.RequestDocumentation
 import org.springframework.restdocs.request.RequestDocumentation.parameterWithName
 import org.springframework.restdocs.request.RequestDocumentation.queryParameters
@@ -34,13 +36,27 @@ class CommunityCommentControllerDocsTestTest : CommonDocsTestConfig() {
         // given
         val response = GetCommunityCommentsDto.Response(
             listOf(
-                GetCommunityCommentsDto.CommunityComment(
-                    id = 2,
-                    upperCommentId = 1,
-                    content = "내용",
-                    LocalDateTime.now(),
-                    "작성자 ID",
-                    "작성자 닉네임"
+                GetCommunityCommentsDto.CommunityCommentList(
+                    parentComment = GetCommunityCommentsDto.CommunityComment(
+                        id = 1,
+                        upperCommentId = null,
+                        content = "상위 내용",
+                        status = CommunityCommentType.CREATED,
+                        LocalDateTime.now(),
+                        "작성자 ID",
+                        "작성자 닉네임"
+                    ),
+                    childComments = listOf(
+                        GetCommunityCommentsDto.CommunityComment(
+                            id = 2,
+                            upperCommentId = 1,
+                            content = "하위 내용",
+                            status = CommunityCommentType.CREATED,
+                            LocalDateTime.now(),
+                            "작성자 ID",
+                            "작성자 닉네임"
+                        )
+                    )
                 )
             )
         )
@@ -67,12 +83,20 @@ class CommunityCommentControllerDocsTestTest : CommonDocsTestConfig() {
                     ),
                     PayloadDocumentation.responseFields(
                         *commonResponseFields(),
-                        PayloadDocumentation.fieldWithPath("result.comments[].id").type(JsonFieldType.NUMBER).description("코멘트 아이디"),
-                        PayloadDocumentation.fieldWithPath("result.comments[].upperCommentId").type(JsonFieldType.NUMBER).description("상위 코멘트 아이디").optional(),
-                        PayloadDocumentation.fieldWithPath("result.comments[].content").type(JsonFieldType.STRING).description("코멘트 내용"),
-                        PayloadDocumentation.fieldWithPath("result.comments[].createdAt").type("LocalDateTime").description("작성일자"),
-                        PayloadDocumentation.fieldWithPath("result.comments[].createdBy").type(JsonFieldType.STRING).description("작성자 ID"),
-                        PayloadDocumentation.fieldWithPath("result.comments[].writer").type(JsonFieldType.STRING).description("작성자 닉네임"),
+                        fieldWithPath("result.comments[].parentComment.id").type(JsonFieldType.NUMBER).description("코멘트 아이디"),
+                        fieldWithPath("result.comments[].parentComment.upperCommentId").type(JsonFieldType.NUMBER).description("상위 코멘트 아이디").optional(),
+                        fieldWithPath("result.comments[].parentComment.content").type(JsonFieldType.STRING).description("코멘트 내용"),
+                        fieldWithPath("result.comments[].parentComment.status").type("CommunityCommentType").description("코멘트 상태").attributes(getFormatAttribute("CREATED, DELETED")),
+                        fieldWithPath("result.comments[].parentComment.createdAt").type("LocalDateTime").description("작성일자"),
+                        fieldWithPath("result.comments[].parentComment.createdBy").type(JsonFieldType.STRING).description("작성자 ID"),
+                        fieldWithPath("result.comments[].parentComment.writer").type(JsonFieldType.STRING).description("작성자 닉네임"),
+                        fieldWithPath("result.comments[].childComments[].id").type(JsonFieldType.NUMBER).description("코멘트 아이디"),
+                        fieldWithPath("result.comments[].childComments[].upperCommentId").type(JsonFieldType.NUMBER).description("상위 코멘트 아이디").optional(),
+                        fieldWithPath("result.comments[].childComments[].content").type(JsonFieldType.STRING).description("코멘트 내용"),
+                        fieldWithPath("result.comments[].childComments[].status").type("CommunityCommentType").description("코멘트 상태").attributes(getFormatAttribute("CREATED, DELETED")),
+                        fieldWithPath("result.comments[].childComments[].createdAt").type("LocalDateTime").description("작성일자"),
+                        fieldWithPath("result.comments[].childComments[].createdBy").type(JsonFieldType.STRING).description("작성자 ID"),
+                        fieldWithPath("result.comments[].childComments[].writer").type(JsonFieldType.STRING).description("작성자 닉네임"),
                     )
                 )
             )
@@ -116,15 +140,15 @@ class CommunityCommentControllerDocsTestTest : CommonDocsTestConfig() {
                         headerWithName("Authorization").description("엑세스 토큰")
                     ),
                     PayloadDocumentation.requestFields(
-                        PayloadDocumentation.fieldWithPath("postId").description("코멘트 생성할 게시글 아이디"),
-                        PayloadDocumentation.fieldWithPath("upperCommentId").description("상위 코멘트 아이디").optional(),
-                        PayloadDocumentation.fieldWithPath("content").description("생성할 내용")
+                        fieldWithPath("postId").description("코멘트 생성할 게시글 아이디"),
+                        fieldWithPath("upperCommentId").description("상위 코멘트 아이디").optional(),
+                        fieldWithPath("content").description("생성할 내용")
                     ),
                     PayloadDocumentation.responseFields(
                         *commonResponseFields(),
-                        PayloadDocumentation.fieldWithPath("result.id").type(JsonFieldType.NUMBER).description("생성된 코멘트 아이디"),
-                        PayloadDocumentation.fieldWithPath("result.upperCommentId").type(JsonFieldType.NUMBER).description("연결된 상위 코멘트 아이디").optional(),
-                        PayloadDocumentation.fieldWithPath("result.content").type(JsonFieldType.STRING).description("생성된 내용"),
+                        fieldWithPath("result.id").type(JsonFieldType.NUMBER).description("생성된 코멘트 아이디"),
+                        fieldWithPath("result.upperCommentId").type(JsonFieldType.NUMBER).description("연결된 상위 코멘트 아이디").optional(),
+                        fieldWithPath("result.content").type(JsonFieldType.STRING).description("생성된 내용"),
                     )
                 )
             )
@@ -168,12 +192,12 @@ class CommunityCommentControllerDocsTestTest : CommonDocsTestConfig() {
                         parameterWithName("commentId").description("변경할 코멘트 아이디")
                     ),
                     PayloadDocumentation.requestFields(
-                        PayloadDocumentation.fieldWithPath("content").description("변경할 내용"),
+                        fieldWithPath("content").description("변경할 내용"),
                     ),
                     PayloadDocumentation.responseFields(
                         *commonResponseFields(),
-                        PayloadDocumentation.fieldWithPath("result.id").type(JsonFieldType.NUMBER).description("변경된 코멘트 아이디"),
-                        PayloadDocumentation.fieldWithPath("result.content").type(JsonFieldType.STRING).description("변경된 내용"),
+                        fieldWithPath("result.id").type(JsonFieldType.NUMBER).description("변경된 코멘트 아이디"),
+                        fieldWithPath("result.content").type(JsonFieldType.STRING).description("변경된 내용"),
                     )
                 )
             )
@@ -211,7 +235,7 @@ class CommunityCommentControllerDocsTestTest : CommonDocsTestConfig() {
                     ),
                     PayloadDocumentation.responseFields(
                         *commonResponseFields(),
-                        PayloadDocumentation.fieldWithPath("result.id").type(JsonFieldType.NUMBER).description("삭제된 코멘트 아이디"),
+                        fieldWithPath("result.id").type(JsonFieldType.NUMBER).description("삭제된 코멘트 아이디"),
                     )
                 )
             )


### PR DESCRIPTION
## 📚 개요
- #104 

## ✏️ 작업 내용
- 코멘트 단순 리스트에서 상위, 하위 코멘트 분리하여 전달하도록 구현

