### PR TITLE
:bug: 게시글 생성 시 카테고리 타입 적용 안 되는 문제 수정 (#118)

### DIFF
--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/post/CreateCommunityPostDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/post/CreateCommunityPostDto.kt
@@ -20,7 +20,7 @@ class CreateCommunityPostDto {
             return CreateCommunityPostCommand(
                 title = title,
                 content = content,
-                categoryType = CommunityCategoryType.ISSUE,
+                categoryType = categoryType,
                 hashTags = arrayListOf(),
                 subwayLineId = 1,
                 imageFiles = imageFiles


### PR DESCRIPTION
## 📚 개요
- #118 

## ✏️ 작업 내용
- 게시글 생성 시 카테고리 값 하드코딩 제거
