### PR TITLE
✨ 게시글 목록 조회 일부 컬럼 추가 및 네이밍 수정 (#121)

### DIFF
--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/post/SearchCommunityPostDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/post/SearchCommunityPostDto.kt
@@ -5,7 +5,6 @@ import backend.team.ahachul_backend.api.community.domain.model.CommunityCategory
 import backend.team.ahachul_backend.common.dto.ImageDto
 import backend.team.ahachul_backend.common.model.RegionType
 import org.springframework.data.domain.Pageable
-import org.springframework.data.domain.Slice
 import java.time.LocalDateTime
 
 class SearchCommunityPostDto {
@@ -44,24 +43,28 @@ class SearchCommunityPostDto {
     data class CommunityPost(
         val id: Long,
         val title: String,
+        val content: String,
         val categoryType: CommunityCategoryType,
-        val views: Int,
-        val likes: Int,
-        val region: RegionType,
+        val commentCnt: Int,
+        val viewCnt: Int,
+        val likeCnt: Int,
+        val regionType: RegionType,
         val createdAt: LocalDateTime,
         val createdBy: String,
         val writer: String,
         val image: ImageDto?,
     ) {
         companion object {
-            fun of(entity: CommunityPostEntity, image: ImageDto?, views: Int): CommunityPost {
+            fun of(entity: CommunityPostEntity, image: ImageDto?, views: Int, commentCnt: Int): CommunityPost {
                 return CommunityPost(
                     id = entity.id,
                     title = entity.title,
+                    content = entity.content,
                     categoryType = entity.categoryType,
-                    views = views,
-                    likes = 0, // TODO
-                    region = entity.regionType,
+                    commentCnt = commentCnt,
+                    viewCnt = views,
+                    likeCnt = 0, // TODO
+                    regionType = entity.regionType,
                     createdAt = entity.createdAt,
                     createdBy = entity.createdBy,
                     writer = entity.member!!.nickname!!,

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/out/CommunityCommentPersistence.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/out/CommunityCommentPersistence.kt
@@ -28,4 +28,8 @@ class CommunityCommentPersistence(
     override fun findAllByPostId(postId: Long): List<CommunityCommentEntity> {
         return repository.findAllByCommunityPostId(postId)
     }
+
+    override fun count(postId: Long): Int {
+        return repository.countByCommunityPostId(postId)
+    }
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/out/CommunityCommentRepository.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/out/CommunityCommentRepository.kt
@@ -12,4 +12,6 @@ interface CommunityCommentRepository: JpaRepository<CommunityCommentEntity, Long
             "WHERE cc.communityPost.id = :postId " +
             "ORDER BY cc.createdAt ASC")
     fun findAllByCommunityPostId(postId: Long): List<CommunityCommentEntity>
+
+    fun countByCommunityPostId(postId: Long): Int
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/application/port/out/CommunityCommentReader.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/application/port/out/CommunityCommentReader.kt
@@ -9,4 +9,6 @@ interface CommunityCommentReader {
     fun findById(id: Long): CommunityCommentEntity?
 
     fun findAllByPostId(postId: Long): List<CommunityCommentEntity>
+
+    fun count(postId: Long): Int
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/application/service/CommunityPostService.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/application/service/CommunityPostService.kt
@@ -2,10 +2,7 @@ package backend.team.ahachul_backend.api.community.application.service
 
 import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.post.*
 import backend.team.ahachul_backend.api.community.application.port.`in`.CommunityPostUseCase
-import backend.team.ahachul_backend.api.community.application.port.out.CommunityPostFileReader
-import backend.team.ahachul_backend.api.community.application.port.out.CommunityPostHashTagReader
-import backend.team.ahachul_backend.api.community.application.port.out.CommunityPostReader
-import backend.team.ahachul_backend.api.community.application.port.out.CommunityPostWriter
+import backend.team.ahachul_backend.api.community.application.port.out.*
 import backend.team.ahachul_backend.api.community.domain.entity.CommunityPostEntity
 import backend.team.ahachul_backend.api.community.domain.entity.CommunityPostFileEntity
 import backend.team.ahachul_backend.api.member.application.port.out.MemberReader
@@ -26,6 +23,7 @@ class CommunityPostService(
     private val subwayLineReader: SubwayLineReader,
     private val communityPostHashTagReader: CommunityPostHashTagReader,
     private val communityPostFileReader: CommunityPostFileReader,
+    private val communityCommentReader: CommunityCommentReader,
 
     private val communityPostHashTagService: CommunityPostHashTagService,
     private val communityPostFileService: CommunityPostFileService,
@@ -41,7 +39,8 @@ class CommunityPostService(
                 SearchCommunityPostDto.CommunityPost.of(
                     entity = it,
                     image = file?.let { it1 -> ImageDto.of(it1.id, file.filePath) },
-                    views = viewsSupport.get(it.id)
+                    views = viewsSupport.get(it.id),
+                    commentCnt = communityCommentReader.count(it.id)
                 )
             }.toList()
 

--- a/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/CommunityPostControllerDocsTest.kt
+++ b/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/CommunityPostControllerDocsTest.kt
@@ -81,7 +81,7 @@ class CommunityPostControllerDocsTest : CommonDocsTestConfig() {
                         parameterWithName("content").description("검색하고자 하는 내용").optional(),
                         parameterWithName("hashTag").description("검색하고자 하는 해시 태그").optional(),
                         parameterWithName("page").description("현재 페이지"),
-                        parameterWithName("size").description("페이지 노출 데이터 수"),
+                        parameterWithName("size").description("페이지 노출 데이터 수. index 0부터 시작"),
                         parameterWithName("sort").description("정렬 조건").attributes(getFormatAttribute("(likes|createdAt|views),(asc|desc)")),
                     ),
                     responseFields(

--- a/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/CommunityPostControllerDocsTest.kt
+++ b/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/CommunityPostControllerDocsTest.kt
@@ -36,16 +36,18 @@ class CommunityPostControllerDocsTest : CommonDocsTestConfig() {
             true,
             listOf(
                 SearchCommunityPostDto.CommunityPost(
-                    1,
-                    "제목",
-                    CommunityCategoryType.ISSUE,
-                    0,
-                    0,
-                    RegionType.METROPOLITAN,
-                    LocalDateTime.now(),
-                    "작성자 ID",
-                    "작성자 닉네임",
-                    ImageDto.of(1L, "url1")
+                    id = 1,
+                    title = "제목",
+                    content = "내용",
+                    categoryType = CommunityCategoryType.ISSUE,
+                    commentCnt = 0,
+                    viewCnt = 0,
+                    likeCnt = 0,
+                    regionType = RegionType.METROPOLITAN,
+                    createdAt = LocalDateTime.now(),
+                    createdBy = "작성자 ID",
+                    writer = "작성자 닉네임",
+                    image = ImageDto.of(1L, "url1")
                 )
             )
         )
@@ -87,10 +89,12 @@ class CommunityPostControllerDocsTest : CommonDocsTestConfig() {
                         fieldWithPath("result.hasNext").type(JsonFieldType.BOOLEAN).description("다음 페이지 존재 여부"),
                         fieldWithPath("result.posts[].id").type(JsonFieldType.NUMBER).description("게시글 아이디"),
                         fieldWithPath("result.posts[].title").type(JsonFieldType.STRING).description("게시글 제목"),
+                        fieldWithPath("result.posts[].content").type(JsonFieldType.STRING).description("게시글 내용"),
                         fieldWithPath("result.posts[].categoryType").type("CategoryType").description("카테고리 타입").attributes(getFormatAttribute("FREE, INSIGHT, ISSUE, HUMOR")),
-                        fieldWithPath("result.posts[].views").type(JsonFieldType.NUMBER).description("조회수"),
-                        fieldWithPath("result.posts[].likes").type(JsonFieldType.NUMBER).description("좋아요 수"),
-                        fieldWithPath("result.posts[].region").type("RegionType").description("지역").attributes(getFormatAttribute("METROPOLITAN")),
+                        fieldWithPath("result.posts[].commentCnt").type(JsonFieldType.NUMBER).description("댓글 수"),
+                        fieldWithPath("result.posts[].viewCnt").type(JsonFieldType.NUMBER).description("조회수"),
+                        fieldWithPath("result.posts[].likeCnt").type(JsonFieldType.NUMBER).description("좋아요 수"),
+                        fieldWithPath("result.posts[].regionType").type("RegionType").description("지역").attributes(getFormatAttribute("METROPOLITAN")),
                         fieldWithPath("result.posts[].createdAt").type("LocalDateTime").description("작성일자"),
                         fieldWithPath("result.posts[].createdBy").type(JsonFieldType.STRING).description("작성자 ID"),
                         fieldWithPath("result.posts[].writer").type(JsonFieldType.STRING).description("작성자 닉네임"),


### PR DESCRIPTION
## 📚 개요
- #121 

## ✏️ 작업 내용
- 댓글 수, 게시글 내용 추가
- 조회수, 좋아요 수 네이밍 수정 (네이밍 통일)
- 지역 네이밍 수정 (구체화)
- 게시글 조회 페이지네이션 관련 설명 추가
