### PR TITLE
✨ 커뮤니티 게시글 조회 로직 수정 및 버그 수정

### DIFF
--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/post/GetCommunityPostDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/post/GetCommunityPostDto.kt
@@ -1,6 +1,6 @@
 package backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.post
 
-import backend.team.ahachul_backend.api.community.domain.CommunityPost
+import backend.team.ahachul_backend.api.community.domain.GetCommunityPost
 import backend.team.ahachul_backend.api.community.domain.model.CommunityCategoryType
 import backend.team.ahachul_backend.common.dto.ImageDto
 import backend.team.ahachul_backend.common.model.RegionType
@@ -28,23 +28,23 @@ class GetCommunityPostDto {
         val images: List<ImageDto>
     ) {
         companion object {
-            fun of(communityPost: CommunityPost, hashTags: List<String>, views: Int, images: List<ImageDto>): Response {
+            fun of(getCommunityPost: GetCommunityPost, hashTags: List<String>, views: Int, images: List<ImageDto>): Response {
                 return Response(
-                    id = communityPost.id,
-                    title = communityPost.title,
-                    content = communityPost.content,
-                    categoryType = communityPost.categoryType,
+                    id = getCommunityPost.id,
+                    title = getCommunityPost.title,
+                    content = getCommunityPost.content,
+                    categoryType = getCommunityPost.categoryType,
                     hashTags = hashTags,
                     viewCnt = views,
-                    likeCnt = communityPost.likeCnt.toInt(),
-                    hateCnt = communityPost.hateCnt.toInt(),
-                    likeYn = YNType.convert(communityPost.likeYn),
-                    hateYn = YNType.convert(communityPost.hateYn),
-                    regionType = communityPost.regionType,
-                    subwayLineId = communityPost.subwayLineId,
-                    createdAt = communityPost.createdAt,
-                    createdBy = communityPost.createdBy,
-                    writer = communityPost.writer,
+                    likeCnt = getCommunityPost.likeCnt.toInt(),
+                    hateCnt = getCommunityPost.hateCnt.toInt(),
+                    likeYn = YNType.convert(getCommunityPost.likeYn),
+                    hateYn = YNType.convert(getCommunityPost.hateYn),
+                    regionType = getCommunityPost.regionType,
+                    subwayLineId = getCommunityPost.subwayLineId,
+                    createdAt = getCommunityPost.createdAt,
+                    createdBy = getCommunityPost.createdBy,
+                    writer = getCommunityPost.writer,
                     images = images
                 )
             }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/post/SearchCommunityPostDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/post/SearchCommunityPostDto.kt
@@ -28,12 +28,14 @@ class SearchCommunityPostDto {
 
     data class Response(
         val hasNext: Boolean,
+        val nextPageNum: Int?,
         val posts: List<CommunityPost>,
     ) {
         companion object {
-            fun of(hasNext: Boolean, posts: List<CommunityPost>): Response {
+            fun of(hasNext: Boolean, posts: List<CommunityPost>, currentPageNum: Int): Response {
                 return Response(
                     hasNext = hasNext,
+                    nextPageNum = if (hasNext) currentPageNum + 1 else null,
                     posts = posts
                 )
             }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/post/SearchCommunityPostDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/post/SearchCommunityPostDto.kt
@@ -1,6 +1,6 @@
 package backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.post
 
-import backend.team.ahachul_backend.api.community.domain.entity.CommunityPostEntity
+import backend.team.ahachul_backend.api.community.domain.SearchCommunityPost
 import backend.team.ahachul_backend.api.community.domain.model.CommunityCategoryType
 import backend.team.ahachul_backend.common.dto.ImageDto
 import backend.team.ahachul_backend.common.model.RegionType
@@ -46,9 +46,9 @@ class SearchCommunityPostDto {
         val content: String,
         val categoryType: CommunityCategoryType,
         val hashTags: List<String>,
-        val commentCnt: Int,
+        val commentCnt: Long,
         val viewCnt: Int,
-        val likeCnt: Int,
+        val likeCnt: Long,
         val regionType: RegionType,
         val subwayLineId: Long,
         val createdAt: LocalDateTime,
@@ -57,21 +57,21 @@ class SearchCommunityPostDto {
         val image: ImageDto?,
     ) {
         companion object {
-            fun of(entity: CommunityPostEntity, image: ImageDto?, views: Int, commentCnt: Int,  likeCnt: Int): CommunityPost {
+            fun of(searchCommunityPost: SearchCommunityPost, image: ImageDto?, views: Int, hashTags: List<String>): CommunityPost {
                 return CommunityPost(
-                    id = entity.id,
-                    title = entity.title,
-                    content = entity.content,
-                    categoryType = entity.categoryType,
-                    hashTags = entity.communityPostHashTags.map { it.hashTag.name },
-                    commentCnt = commentCnt,
+                    id = searchCommunityPost.id,
+                    title = searchCommunityPost.title,
+                    content = searchCommunityPost.content,
+                    categoryType = searchCommunityPost.categoryType,
+                    hashTags = hashTags,
+                    commentCnt = searchCommunityPost.commentCnt,
                     viewCnt = views,
-                    likeCnt = likeCnt,
-                    regionType = entity.regionType,
-                    subwayLineId = entity.subwayLineEntity.id,
-                    createdAt = entity.createdAt,
-                    createdBy = entity.createdBy,
-                    writer = entity.member!!.nickname!!,
+                    likeCnt = searchCommunityPost.likeCnt,
+                    regionType = searchCommunityPost.regionType,
+                    subwayLineId = searchCommunityPost.subwayLineId,
+                    createdAt = searchCommunityPost.createdAt,
+                    createdBy = searchCommunityPost.createdBy,
+                    writer = searchCommunityPost.writer,
                     image = image,
                 )
             }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/out/CommunityPostPersistence.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/out/CommunityPostPersistence.kt
@@ -3,7 +3,8 @@ package backend.team.ahachul_backend.api.community.adapter.web.out
 import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.post.SearchCommunityPostCommand
 import backend.team.ahachul_backend.api.community.application.port.out.CommunityPostReader
 import backend.team.ahachul_backend.api.community.application.port.out.CommunityPostWriter
-import backend.team.ahachul_backend.api.community.domain.CommunityPost
+import backend.team.ahachul_backend.api.community.domain.GetCommunityPost
+import backend.team.ahachul_backend.api.community.domain.SearchCommunityPost
 import backend.team.ahachul_backend.api.community.domain.entity.CommunityPostEntity
 import backend.team.ahachul_backend.common.exception.AdapterException
 import backend.team.ahachul_backend.common.response.ResponseCode
@@ -25,11 +26,11 @@ class CommunityPostPersistence(
             .orElseThrow { throw AdapterException(ResponseCode.INVALID_DOMAIN) }
     }
 
-    override fun getByCustom(postId: Long, memberId: String?): CommunityPost {
+    override fun getByCustom(postId: Long, memberId: String?): GetCommunityPost {
         return customRepository.getByCustom(postId, memberId) ?: throw AdapterException(ResponseCode.INVALID_DOMAIN)
     }
 
-    override fun searchCommunityPosts(command: SearchCommunityPostCommand): Slice<CommunityPostEntity> {
+    override fun searchCommunityPosts(command: SearchCommunityPostCommand): Slice<SearchCommunityPost> {
         return customRepository.searchCommunityPosts(command)
     }
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/application/port/out/CommunityPostReader.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/application/port/out/CommunityPostReader.kt
@@ -1,7 +1,8 @@
 package backend.team.ahachul_backend.api.community.application.port.out
 
 import backend.team.ahachul_backend.api.community.adapter.web.`in`.dto.post.SearchCommunityPostCommand
-import backend.team.ahachul_backend.api.community.domain.CommunityPost
+import backend.team.ahachul_backend.api.community.domain.GetCommunityPost
+import backend.team.ahachul_backend.api.community.domain.SearchCommunityPost
 import backend.team.ahachul_backend.api.community.domain.entity.CommunityPostEntity
 import org.springframework.data.domain.Slice
 
@@ -9,7 +10,7 @@ interface CommunityPostReader {
 
     fun getCommunityPost(id: Long): CommunityPostEntity
 
-    fun getByCustom(postId: Long, memberId: String?): CommunityPost
+    fun getByCustom(postId: Long, memberId: String?): GetCommunityPost
 
-    fun searchCommunityPosts(command: SearchCommunityPostCommand): Slice<CommunityPostEntity>
+    fun searchCommunityPosts(command: SearchCommunityPostCommand): Slice<SearchCommunityPost>
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/application/service/CommunityPostLikeService.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/application/service/CommunityPostLikeService.kt
@@ -71,7 +71,7 @@ class CommunityPostLikeService (
             CommunityPostLikeEntity.of(
                 communityPost = communityPostReader.getCommunityPost(postId),
                 member = memberReader.getMember(memberId),
-                YNType.Y
+                YNType.N
             )
         )
     }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/application/service/CommunityPostService.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/application/service/CommunityPostService.kt
@@ -7,7 +7,6 @@ import backend.team.ahachul_backend.api.community.domain.entity.CommunityPostEnt
 import backend.team.ahachul_backend.api.community.domain.entity.CommunityPostFileEntity
 import backend.team.ahachul_backend.api.member.application.port.out.MemberReader
 import backend.team.ahachul_backend.common.dto.ImageDto
-import backend.team.ahachul_backend.common.model.YNType
 import backend.team.ahachul_backend.common.persistence.SubwayLineReader
 import backend.team.ahachul_backend.common.support.ViewsSupport
 import backend.team.ahachul_backend.common.utils.RequestUtils
@@ -24,8 +23,6 @@ class CommunityPostService(
     private val subwayLineReader: SubwayLineReader,
     private val communityPostHashTagReader: CommunityPostHashTagReader,
     private val communityPostFileReader: CommunityPostFileReader,
-    private val communityCommentReader: CommunityCommentReader,
-    private val communityPostLikeReader: CommunityPostLikeReader,
 
     private val communityPostHashTagService: CommunityPostHashTagService,
     private val communityPostFileService: CommunityPostFileService,
@@ -39,11 +36,10 @@ class CommunityPostService(
             .map {
                 val file = communityPostFileReader.findByPostId(it.id)?.file
                 SearchCommunityPostDto.CommunityPost.of(
-                    entity = it,
+                    searchCommunityPost = it,
                     image = file?.let { it1 -> ImageDto.of(it1.id, file.filePath) },
                     views = viewsSupport.get(it.id),
-                    commentCnt = communityCommentReader.count(it.id),
-                    likeCnt = communityPostLikeReader.count(it.id, YNType.Y)
+                    hashTags = communityPostHashTagReader.findAllByPostId(it.id).map { it.hashTag.name }
                 )
             }.toList()
 

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/application/service/CommunityPostService.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/application/service/CommunityPostService.kt
@@ -45,7 +45,8 @@ class CommunityPostService(
 
         return SearchCommunityPostDto.Response.of(
             hasNext = searchCommunityPosts.hasNext(),
-            posts = posts
+            posts = posts,
+            command.pageable.pageNumber,
         )
     }
 

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/domain/GetCommunityPost.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/domain/GetCommunityPost.kt
@@ -4,7 +4,7 @@ import backend.team.ahachul_backend.api.community.domain.model.CommunityCategory
 import backend.team.ahachul_backend.common.model.RegionType
 import java.time.LocalDateTime
 
-data class CommunityPost(
+data class GetCommunityPost(
     val id: Long,
     val title: String,
     val content: String,

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/domain/SearchCommunityPost.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/community/domain/SearchCommunityPost.kt
@@ -1,0 +1,20 @@
+package backend.team.ahachul_backend.api.community.domain
+
+import backend.team.ahachul_backend.api.community.domain.model.CommunityCategoryType
+import backend.team.ahachul_backend.common.model.RegionType
+import java.time.LocalDateTime
+
+data class SearchCommunityPost(
+    val id: Long,
+    val title: String,
+    val content: String,
+    val categoryType: CommunityCategoryType,
+    val regionType: RegionType,
+    val subwayLineId: Long,
+    val likeCnt: Long,
+    val commentCnt: Long,
+    val createdAt: LocalDateTime,
+    val createdBy: String,
+    val writer: String,
+) {
+}

--- a/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/CommunityPostControllerDocsTest.kt
+++ b/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/CommunityPostControllerDocsTest.kt
@@ -35,6 +35,7 @@ class CommunityPostControllerDocsTest : CommonDocsTestConfig() {
         // given
         val response = SearchCommunityPostDto.Response(
             true,
+            1,
             listOf(
                 SearchCommunityPostDto.CommunityPost(
                     id = 1,
@@ -90,6 +91,7 @@ class CommunityPostControllerDocsTest : CommonDocsTestConfig() {
                     responseFields(
                         *commonResponseFields(),
                         fieldWithPath("result.hasNext").type(JsonFieldType.BOOLEAN).description("다음 페이지 존재 여부"),
+                        fieldWithPath("result.nextPageNum").type(JsonFieldType.NUMBER).description("다음 페이지 인덱스"),
                         fieldWithPath("result.posts[].id").type(JsonFieldType.NUMBER).description("게시글 아이디"),
                         fieldWithPath("result.posts[].title").type(JsonFieldType.STRING).description("게시글 제목"),
                         fieldWithPath("result.posts[].content").type(JsonFieldType.STRING).description("게시글 내용"),


### PR DESCRIPTION
## 📚 개요
- #129 

## ✏️ 작업 내용
- 게시글 리스트 조회 쿼리 수정
- 게시글 리스트 조회 API response 다음 페이지 인덱스 추가
- 게시글 좋아요 필터링 안되는 문제 수정
- 최초 싫어요 경우 좋아요로 되는 문제 수정
