### PR TITLE
:bug: 유실물 스케줄링에서 카테고리 엔티티 매핑 실패 해결 (#159)

### DIFF
--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/lost/domain/entity/LostPostEntity.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/lost/domain/entity/LostPostEntity.kt
@@ -10,7 +10,7 @@ import backend.team.ahachul_backend.api.member.domain.entity.MemberEntity
 import backend.team.ahachul_backend.api.report.domain.ReportEntity
 import backend.team.ahachul_backend.common.domain.entity.SubwayLineEntity
 import backend.team.ahachul_backend.common.entity.BaseEntity
-import backend.team.ahachul_backend.schedule.Lost112Data
+import backend.team.ahachul_backend.schedule.domain.Lost112Data
 import jakarta.persistence.*
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/storage/CategoryStorage.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/storage/CategoryStorage.kt
@@ -14,6 +14,12 @@ class CategoryStorage(
         categories = categoryReader.getCategories()
     }
 
+    fun extractPrimaryCategory(categoryName: String): String{
+        val idx = categoryName.indexOf(">")
+        val primaryCategory = categoryName.substring(0, idx)
+        return primaryCategory.trim()
+    }
+
     fun getCategoryByName(categoryName: String): CategoryEntity? {
         return runCatching {
             categories.first { category -> category.name == categoryName }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/schedule/domain/Lost112Data.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/schedule/domain/Lost112Data.kt
@@ -1,4 +1,4 @@
-package backend.team.ahachul_backend.schedule
+package backend.team.ahachul_backend.schedule.domain
 
 import com.fasterxml.jackson.annotation.JsonProperty
 

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/schedule/job/UpdateLostDataJob.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/schedule/job/UpdateLostDataJob.kt
@@ -1,6 +1,5 @@
 package backend.team.ahachul_backend.schedule.job
 
-import backend.team.ahachul_backend.api.lost.application.port.out.CategoryReader
 import backend.team.ahachul_backend.api.lost.application.port.out.LostPostWriter
 import backend.team.ahachul_backend.api.lost.application.service.LostPostFileService
 import backend.team.ahachul_backend.api.lost.domain.entity.CategoryEntity
@@ -9,7 +8,7 @@ import backend.team.ahachul_backend.common.domain.entity.SubwayLineEntity
 import backend.team.ahachul_backend.common.storage.CategoryStorage
 import backend.team.ahachul_backend.common.storage.SubwayLineStorage
 import backend.team.ahachul_backend.common.utils.FileUtils
-import backend.team.ahachul_backend.schedule.Lost112Data
+import backend.team.ahachul_backend.schedule.domain.Lost112Data
 import org.quartz.JobExecutionContext
 import org.springframework.scheduling.quartz.QuartzJobBean
 import org.springframework.stereotype.Component

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/schedule/job/UpdateLostDataJob.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/schedule/job/UpdateLostDataJob.kt
@@ -48,8 +48,7 @@ class UpdateLostDataJob(
     }
 
     private fun getCategory(categoryName: String): CategoryEntity? {
-        val idx = categoryName.trim().indexOf(">")
-        val primaryCategoryName = categoryName.substring(0, idx)
+        val primaryCategoryName = categoryStorage.extractPrimaryCategory(categoryName)
         return categoryStorage.getCategoryByName(primaryCategoryName)
     }
 }

--- a/ahachul_backend/src/main/resources/db/migration/V202308221709__update_lost_category_null.sql
+++ b/ahachul_backend/src/main/resources/db/migration/V202308221709__update_lost_category_null.sql
@@ -1,0 +1,1 @@
+alter table tb_lost_post modify category_id bigint null;

--- a/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/common/storage/CategoryStorageTest.kt
+++ b/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/common/storage/CategoryStorageTest.kt
@@ -1,0 +1,38 @@
+package backend.team.ahachul_backend.common.storage
+
+import backend.team.ahachul_backend.config.controller.CommonServiceTestConfig
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class CategoryStorageTest(
+    @Autowired private val categoryStorage: CategoryStorage
+): CommonServiceTestConfig() {
+
+    @Test
+    @DisplayName("주요 카테고리만 추출해서 반환한다.")
+    fun extractSubwayLine() {
+        // given
+        val categoryName = "가방 > 기타가방"
+
+        // when
+        val result = categoryStorage.extractPrimaryCategory(categoryName)
+
+        // then
+        assertThat(result).isEqualTo("가방")
+    }
+
+    @Test
+    @DisplayName("시드 카테고리와 일치하는 데이터가 없다면 null을 반환한다.")
+    fun getSubwayLineNull() {
+        // given
+        val categoryName = "음식 > 과자"
+
+        // when
+        val result = categoryStorage.getCategoryByName(categoryName)
+
+        // then
+        assertThat(result).isEqualTo(null)
+    }
+}

--- a/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/common/storage/SubwayLineStorageTest.kt
+++ b/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/common/storage/SubwayLineStorageTest.kt
@@ -1,0 +1,38 @@
+package backend.team.ahachul_backend.common.storage
+
+import backend.team.ahachul_backend.config.controller.CommonServiceTestConfig
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class SubwayLineStorageTest(
+    @Autowired private val subwayLineStorage: SubwayLineStorage
+): CommonServiceTestConfig() {
+
+    @Test
+    @DisplayName("호선 정보만 추출해서 반환한다.")
+    fun extractSubwayLine() {
+        // given
+        val subwayLineName = "숭실대입구역(7호선)"
+
+        // when
+        val result = subwayLineStorage.extractSubWayLine(subwayLineName)
+
+        // then
+        assertThat(result).isEqualTo("7호선")
+    }
+
+    @Test
+    @DisplayName("시드 호선과 일치하는 호선 정보가 없다면 null을 반환한다.")
+    fun getSubwayLineNull() {
+        // given
+        val subwayLineName = "인천국제공항(터미널1)"
+
+        // when
+        val result = subwayLineStorage.getSubwayLineEntityByName(subwayLineName)
+
+        // then
+        assertThat(result).isEqualTo(null)
+    }
+}


### PR DESCRIPTION
## 📚 개요
+ #159 

## ✏️ 작업 내용
+ lost_post에서 카테고리 필드 null 허용
+ 카테고리 이름 추출 로직 수정
+ 지하철 노선 저장소, 카테고리 저장소 테스트 추가

## 💡 주의 사항
+ 테스트의 중요성..!!🥹
