### PR TITLE
:recycle: 특정 정류장 실시간 열차 데이터 캐싱 (#169)

### DIFF
--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/common/application/port/out/StationPersistence.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/common/application/port/out/StationPersistence.kt
@@ -18,7 +18,7 @@ class StationPersistence(
     }
 
     override fun findAllBySubwayLine(subwayLine: SubwayLineEntity): List<StationEntity> {
-        return stationRepository.findAllBySubwayLineEntityOrderByName(subwayLine) ?:
+        return stationRepository.findAllBySubwayLineOrderByName(subwayLine) ?:
             throw DomainException(ResponseCode.INVALID_DOMAIN)
     }
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/common/application/port/out/StationRepository.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/common/application/port/out/StationRepository.kt
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface StationRepository: JpaRepository<StationEntity, Long> {
 
-    fun findAllBySubwayLineEntityOrderByName(subwayLine: SubwayLineEntity): List<StationEntity>?
+    fun findAllBySubwayLineOrderByName(subwayLine: SubwayLineEntity): List<StationEntity>?
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/common/domain/entity/StationEntity.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/common/domain/entity/StationEntity.kt
@@ -19,7 +19,7 @@ class StationEntity(
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "subway_line_id")
-    var subwayLineEntity: SubwayLineEntity
+    var subwayLine: SubwayLineEntity
 
 ): BaseEntity() {
 

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/train/adapter/in/TrainController.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/train/adapter/in/TrainController.kt
@@ -25,8 +25,8 @@ class TrainController(
     
     @GetMapping("/v1/trains/real-times")
     fun getTrainRealTimes(request: GetTrainRealTimesDto.Request): CommonResponse<GetTrainRealTimesDto.Response> {
-        val result = trainUseCase.getTrainRealTimes(request.subwayLineId, request.stationId)
-        return CommonResponse.success(result)
+        val result = trainUseCase.getTrainRealTimes(request.stationId)
+        return CommonResponse.success(GetTrainRealTimesDto.Response(result))
     }
 
     @Authentication

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/train/adapter/in/dto/GetTrainRealTimesDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/train/adapter/in/dto/GetTrainRealTimesDto.kt
@@ -18,7 +18,9 @@ class GetTrainRealTimesDto {
 
     data class TrainRealTime(
         @JsonIgnore
-        val subwayId: String,
+        val subwayId: String?,
+        @JsonIgnore
+        val stationOrder: Int?,
         val upDownType: UpDownType,
         val nextStationDirection: String,
         val destinationStationDirection: String,

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/train/adapter/in/dto/GetTrainRealTimesDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/train/adapter/in/dto/GetTrainRealTimesDto.kt
@@ -2,23 +2,23 @@ package backend.team.ahachul_backend.api.train.adapter.`in`.dto
 
 import backend.team.ahachul_backend.api.train.domain.model.TrainArrivalCode
 import backend.team.ahachul_backend.api.train.domain.model.UpDownType
+import com.fasterxml.jackson.annotation.JsonIgnore
 
 class GetTrainRealTimesDto {
 
     data class Request(
-        val subwayLineId: Long,
         val stationId: Long,
     ) {
     }
 
     data class Response(
-        val subwayLineId: Long,
-        val stationId: Long,
         val trainRealTimes: List<TrainRealTime>,
     ) {
     }
 
     data class TrainRealTime(
+        @JsonIgnore
+        val subwayId: String,
         val upDownType: UpDownType,
         val nextStationDirection: String,
         val destinationStationDirection: String,

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/train/application/port/in/TrainUseCase.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/train/application/port/in/TrainUseCase.kt
@@ -7,5 +7,5 @@ interface TrainUseCase {
 
     fun getTrain(trainNo: String): GetTrainDto.Response
 
-    fun getTrainRealTimes(subwayLineId: Long, stationId: Long): GetTrainRealTimesDto.Response
+    fun getTrainRealTimes(stationId: Long): List<GetTrainRealTimesDto.TrainRealTime>
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/train/application/service/TrainService.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/train/application/service/TrainService.kt
@@ -1,5 +1,6 @@
 package backend.team.ahachul_backend.api.train.application.service
 
+import backend.team.ahachul_backend.api.common.application.port.out.StationReader
 import backend.team.ahachul_backend.api.train.adapter.`in`.dto.GetTrainDto
 import backend.team.ahachul_backend.api.train.adapter.`in`.dto.GetTrainRealTimesDto
 import backend.team.ahachul_backend.api.train.application.port.`in`.TrainUseCase
@@ -7,27 +8,37 @@ import backend.team.ahachul_backend.api.train.application.port.out.TrainReader
 import backend.team.ahachul_backend.api.train.domain.entity.TrainEntity
 import backend.team.ahachul_backend.api.train.domain.model.TrainArrivalCode
 import backend.team.ahachul_backend.api.train.domain.model.UpDownType
+import backend.team.ahachul_backend.common.client.RedisClient
 import backend.team.ahachul_backend.common.client.SeoulTrainClient
 import backend.team.ahachul_backend.common.dto.TrainRealTimeDto
 import backend.team.ahachul_backend.common.exception.AdapterException
 import backend.team.ahachul_backend.common.exception.BusinessException
 import backend.team.ahachul_backend.common.logging.Logger
-import backend.team.ahachul_backend.common.persistence.SubwayLineReader
 import backend.team.ahachul_backend.common.response.ResponseCode
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.util.concurrent.TimeUnit
 
 @Service
 @Transactional(readOnly = true)
 class TrainService(
     private val trainReader: TrainReader,
-    private val subwayLineReader: SubwayLineReader,
-    private val stationLineReader: SubwayLineReader,
+    private val stationLineReader: StationReader,
 
     private val seoulTrainClient: SeoulTrainClient,
+
+    private val redisClient: RedisClient,
+
+    private val objectMapper: ObjectMapper,
 ): TrainUseCase {
 
     private val logger: Logger = Logger(javaClass)
+
+    companion object {
+        const val TRAIN_REAL_TIME_REDIS_PREFIX = "TRAIN_TIME:"
+        const val TRAIN_REAL_TIME_REDIS_EXPIRE_SEC = 25L
+    }
 
     override fun getTrain(trainNo: String): GetTrainDto.Response {
         val (prefixTrainNo, location, organizationTrainNo) = decompositionTrainNo(trainNo)
@@ -54,40 +65,50 @@ class TrainService(
         )
     }
 
-    override fun getTrainRealTimes(subwayLineId: Long, stationId: Long): GetTrainRealTimesDto.Response {
-        val subwayLine = subwayLineReader.getById(subwayLineId)
+    override fun getTrainRealTimes(stationId: Long): List<GetTrainRealTimesDto.TrainRealTime> {
         val station = stationLineReader.getById(stationId)
+        val subwayLine = station.subwayLine
+
+        val cachedData = redisClient.get("$TRAIN_REAL_TIME_REDIS_PREFIX${subwayLine.identity}-${stationId}")
+        cachedData?.let {
+            return objectMapper.readValue(
+                cachedData,
+                objectMapper.typeFactory.constructCollectionType(List::class.java, GetTrainRealTimesDto.TrainRealTime::class.java)
+            )
+        }
+
         var startIndex = 1
         var endIndex = 5
         var totalSize = startIndex
-        val result = mutableListOf<GetTrainRealTimesDto.TrainRealTime>()
+        val trainRealTimes = mutableListOf<GetTrainRealTimesDto.TrainRealTime>()
         while (startIndex <= totalSize) {
-            val trainRealTimes = seoulTrainClient.getTrainRealTimes(station.name, startIndex, endIndex)
-            totalSize = trainRealTimes.errorMessage?.total ?: -1
+            val trainRealTimesPublicData = seoulTrainClient.getTrainRealTimes(station.name, startIndex, endIndex)
+            totalSize = trainRealTimesPublicData.errorMessage?.total ?: break
             startIndex = endIndex + 1
             endIndex = startIndex + 4
-            result.addAll(extractCorrespondingSubwayLine(
-                trainRealTime = trainRealTimes,
-                subwayLineIdentity = subwayLine.identity,
-            ))
+            trainRealTimes.addAll(generateTrainRealTimeList(trainRealTimesPublicData))
         }
 
-        if (result.size == 0) throw BusinessException(ResponseCode.NOT_EXIST_ARRIVAL_TRAIN)
+        if (trainRealTimes.size == 0) throw BusinessException(ResponseCode.NOT_EXIST_ARRIVAL_TRAIN)
 
-        val sortedResult = result.sortedWith(
-            compareBy<GetTrainRealTimesDto.TrainRealTime> { it.currentTrainArrivalCode.priority }
-                .thenBy { it.currentLocation }
-        )
+        val trainRealTimeMap = trainRealTimes.groupBy { it.subwayId }
+            .mapValues { (_, trainRealTimes) ->
+                trainRealTimes.sortedWith(
+                    compareBy<GetTrainRealTimesDto.TrainRealTime> { it.currentTrainArrivalCode.priority }
+                        .thenBy { it.currentLocation }
+                )
+            }
+        trainRealTimeMap.forEach { redisClient.set("$TRAIN_REAL_TIME_REDIS_PREFIX${it.key}-$stationId", it.value, TRAIN_REAL_TIME_REDIS_EXPIRE_SEC, TimeUnit.SECONDS)  }
 
-        return GetTrainRealTimesDto.Response(subwayLineId, stationId, sortedResult)
+        return trainRealTimeMap.getOrElse(subwayLine.identity.toString()) { emptyList() }
     }
 
-    private fun extractCorrespondingSubwayLine(trainRealTime: TrainRealTimeDto, subwayLineIdentity: Long): List<GetTrainRealTimesDto.TrainRealTime> {
+    private fun generateTrainRealTimeList(trainRealTime: TrainRealTimeDto): List<GetTrainRealTimesDto.TrainRealTime> {
         return trainRealTime.realtimeArrivalList
-            ?.filter { it.subwayId == subwayLineIdentity.toString() }
             ?.map {
                 val trainDirection = it.trainLineNm.split("-")
                 GetTrainRealTimesDto.TrainRealTime(
+                    subwayId = it.subwayId,
                     upDownType = UpDownType.from(it.updnLine),
                     nextStationDirection = trainDirection[1].trim(),
                     destinationStationDirection = trainDirection[0].trim(),

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/RedisClient.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/RedisClient.kt
@@ -16,12 +16,16 @@ class RedisClient(
         redisTemplate.opsForValue().set(key, value)
     }
 
+    fun set(key: String, value: String, timeout: Long, timeUnit: TimeUnit) {
+        redisTemplate.opsForValue().set(key, value, timeout, timeUnit)
+    }
+
     fun set(key: String, value: Any) {
         redisTemplate.opsForValue().set(key, objectMapper.writeValueAsString(value))
     }
 
-    fun set(key: String, value: String, timeout: Long, timeUnit: TimeUnit) {
-        redisTemplate.opsForValue().set(key, value, timeout, timeUnit)
+    fun set(key: String, value: Any, timeout: Long, timeUnit: TimeUnit) {
+        redisTemplate.opsForValue().set(key, objectMapper.writeValueAsString(value), timeout, timeUnit)
     }
 
     fun get(key: String): String? {

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/dto/TrainRealTimeDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/dto/TrainRealTimeDto.kt
@@ -8,7 +8,7 @@ data class TrainRealTimeDto(
 }
 
 data class RealtimeArrivalListDTO(
-    val subwayId: String?,
+    val subwayId: String,
     val updnLine: String,
     val trainLineNm: String,
     val statnNm: String?,

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/response/ResponseCode.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/response/ResponseCode.kt
@@ -41,7 +41,7 @@ enum class ResponseCode(
 
     // TRAIN
     INVALID_PREFIX_TRAIN_NO("700", "유효하지 않은 열차 번호입니다.", HttpStatus.BAD_REQUEST),
-    INVALID_SUBWAY_LINE("702", "지원하지 않는 호선입니다.", HttpStatus.BAD_REQUEST),
-    INVALID_TRAIN_NO("703", "현재 운행하지 않는 열차 번호입니다.", HttpStatus.BAD_REQUEST)
     NOT_EXIST_ARRIVAL_TRAIN("701", "열차 도착 정보가 없습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_SUBWAY_LINE("702", "지원하지 않는 호선입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_TRAIN_NO("703", "현재 운행하지 않는 열차 번호입니다.", HttpStatus.BAD_REQUEST),
 }

--- a/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/train/adapter/in/TrainControllerDocsTest.kt
+++ b/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/train/adapter/in/TrainControllerDocsTest.kt
@@ -139,6 +139,7 @@ class TrainControllerDocsTest : CommonDocsTestConfig() {
         val trainRealTimes = listOf(
             GetTrainRealTimesDto.TrainRealTime(
                 subwayId = "",
+                stationOrder = 1,
                 upDownType = UpDownType.DOWN,
                 nextStationDirection = "신대방방면",
                 destinationStationDirection = "성수행",
@@ -148,6 +149,7 @@ class TrainControllerDocsTest : CommonDocsTestConfig() {
             ),
             GetTrainRealTimesDto.TrainRealTime(
                 subwayId = "",
+                stationOrder = 1,
                 upDownType = UpDownType.UP,
                 nextStationDirection = "봉천방면",
                 destinationStationDirection = "성수행",

--- a/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/train/adapter/in/TrainControllerDocsTest.kt
+++ b/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/train/adapter/in/TrainControllerDocsTest.kt
@@ -13,11 +13,7 @@ import org.mockito.ArgumentMatchers.*
 import org.mockito.BDDMockito.*
 import backend.team.ahachul_backend.api.train.domain.model.TrainArrivalCode
 import backend.team.ahachul_backend.api.train.domain.model.UpDownType
-import backend.team.ahachul_backend.config.controller.CommonDocsTestConfig
-import org.junit.jupiter.api.Assertions.*
-import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.anyLong
-import org.mockito.BDDMockito
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.http.MediaType
@@ -26,7 +22,6 @@ import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*
 import org.springframework.restdocs.payload.JsonFieldType
 import org.springframework.restdocs.payload.PayloadDocumentation.*
-import org.springframework.restdocs.payload.PayloadDocumentation
 import org.springframework.restdocs.request.RequestDocumentation.*
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 
@@ -141,36 +136,33 @@ class TrainControllerDocsTest : CommonDocsTestConfig() {
     @Test
     fun getTrainRealTimesTest() {
         // given
-        val response = GetTrainRealTimesDto.Response(
-            subwayLineId = 1L,
-            stationId = 1L,
-            listOf(
-                GetTrainRealTimesDto.TrainRealTime(
-                    upDownType = UpDownType.DOWN,
-                    nextStationDirection = "신대방방면",
-                    destinationStationDirection = "성수행",
-                    trainNum = "2234",
-                    currentLocation = "전역 도착",
-                    currentTrainArrivalCode = TrainArrivalCode.BEFORE_STATION_ARRIVE
-                ),
-                GetTrainRealTimesDto.TrainRealTime(
-                    upDownType = UpDownType.UP,
-                    nextStationDirection = "봉천방면",
-                    destinationStationDirection = "성수행",
-                    trainNum = "2236",
-                    currentLocation = "6분",
-                    currentTrainArrivalCode = TrainArrivalCode.RUNNING
-                )
+        val trainRealTimes = listOf(
+            GetTrainRealTimesDto.TrainRealTime(
+                subwayId = "",
+                upDownType = UpDownType.DOWN,
+                nextStationDirection = "신대방방면",
+                destinationStationDirection = "성수행",
+                trainNum = "2234",
+                currentLocation = "전역 도착",
+                currentTrainArrivalCode = TrainArrivalCode.BEFORE_STATION_ARRIVE
+            ),
+            GetTrainRealTimesDto.TrainRealTime(
+                subwayId = "",
+                upDownType = UpDownType.UP,
+                nextStationDirection = "봉천방면",
+                destinationStationDirection = "성수행",
+                trainNum = "2236",
+                currentLocation = "6분",
+                currentTrainArrivalCode = TrainArrivalCode.RUNNING
             )
         )
 
-        BDDMockito.given(trainUseCase.getTrainRealTimes(anyLong(), anyLong()))
-            .willReturn(response)
+        given(trainUseCase.getTrainRealTimes(anyLong()))
+            .willReturn(trainRealTimes)
 
         // when
         val result = mockMvc.perform(
-            RestDocumentationRequestBuilders.get("/v1/trains/real-times")
-                .queryParam("subwayLineId", "1")
+            get("/v1/trains/real-times")
                 .queryParam("stationId", "1")
                 .header("Authorization", "Bearer <Access Token>")
                 .accept(MediaType.APPLICATION_JSON)
@@ -179,7 +171,7 @@ class TrainControllerDocsTest : CommonDocsTestConfig() {
         // then
         result.andExpect(MockMvcResultMatchers.status().isOk)
             .andDo(
-                MockMvcRestDocumentation.document(
+                document(
                     "get-train-real-times",
                     getDocsRequest(),
                     getDocsResponse(),
@@ -187,20 +179,17 @@ class TrainControllerDocsTest : CommonDocsTestConfig() {
                         HeaderDocumentation.headerWithName("Authorization").description("엑세스 토큰")
                     ),
                     queryParameters(
-                        parameterWithName("subwayLineId").description("지하철 노선 ID"),
                         parameterWithName("stationId").description("정류장 ID")
                     ),
-                    PayloadDocumentation.responseFields(
+                    responseFields(
                         *commonResponseFields(),
-                        PayloadDocumentation.fieldWithPath("result.subwayLineId").type(JsonFieldType.NUMBER).description("지하철 노선 ID"),
-                        PayloadDocumentation.fieldWithPath("result.stationId").type(JsonFieldType.NUMBER).description("정류장 ID"),
-                        PayloadDocumentation.fieldWithPath("result.trainRealTimes[]").type(JsonFieldType.ARRAY).description("해당 정류장 실시간 열차 정보 리스트"),
-                        PayloadDocumentation.fieldWithPath("result.trainRealTimes[].upDownType").type("UpDownType").description("상하행선구분").attributes(getFormatAttribute("UP, DOWN")),
-                        PayloadDocumentation.fieldWithPath("result.trainRealTimes[].nextStationDirection").type(JsonFieldType.STRING).description("다음 정류장 방향"),
-                        PayloadDocumentation.fieldWithPath("result.trainRealTimes[].destinationStationDirection").type(JsonFieldType.STRING).description("목적지 방향"),
-                        PayloadDocumentation.fieldWithPath("result.trainRealTimes[].trainNum").type(JsonFieldType.STRING).description("해당 열차 ID"),
-                        PayloadDocumentation.fieldWithPath("result.trainRealTimes[].currentLocation").type(JsonFieldType.STRING).description("해당 열차 현재 위치"),
-                        PayloadDocumentation.fieldWithPath("result.trainRealTimes[].currentTrainArrivalCode").type(JsonFieldType.STRING).description("해당 열차 현재 위치 코드").attributes(getFormatAttribute("ENTER(진입), ARRIVE(도착), DEPARTURE(출발), BEFORE_STATION_DEPARTURE(전역출발), BEFORE_STATION_ENTER(전역진입), BEFORE_STATION_ARRIVE(전역도착), RUNNING(운행중)")),
+                        fieldWithPath("result.trainRealTimes[]").type(JsonFieldType.ARRAY).description("해당 정류장 실시간 열차 정보 리스트"),
+                        fieldWithPath("result.trainRealTimes[].upDownType").type("UpDownType").description("상하행선구분").attributes(getFormatAttribute("UP, DOWN")),
+                        fieldWithPath("result.trainRealTimes[].nextStationDirection").type(JsonFieldType.STRING).description("다음 정류장 방향"),
+                        fieldWithPath("result.trainRealTimes[].destinationStationDirection").type(JsonFieldType.STRING).description("목적지 방향"),
+                        fieldWithPath("result.trainRealTimes[].trainNum").type(JsonFieldType.STRING).description("해당 열차 ID"),
+                        fieldWithPath("result.trainRealTimes[].currentLocation").type(JsonFieldType.STRING).description("해당 열차 현재 위치"),
+                        fieldWithPath("result.trainRealTimes[].currentTrainArrivalCode").type(JsonFieldType.STRING).description("해당 열차 현재 위치 코드").attributes(getFormatAttribute("ENTER(진입), ARRIVE(도착), DEPARTURE(출발), BEFORE_STATION_DEPARTURE(전역출발), BEFORE_STATION_ENTER(전역진입), BEFORE_STATION_ARRIVE(전역도착), RUNNING(운행중)")),
                     )
                 )
             )


### PR DESCRIPTION
## 📚 개요
- #169 

## ✏️ 작업 내용
- 노선 별 그룹핑 및 캐싱
  - key : TRAIN_TIME:노선ID-정류장ID
  - value : List<GetTrainRealTimesDto.TrainRealTime>
  - 이때 노선ID는 노선 pk가 아닌 identity
  - ttl : 25초

## 💡 주의 사항
- 해당 메서드 그대로 가져가서 쓰면 돼요
