### PR TITLE
:recycle: Redis 자바에서 Json 직렬화 방식으로 변경 

### DIFF
--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/common/adapter/in/CommonController.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/common/adapter/in/CommonController.kt
@@ -3,7 +3,6 @@ package backend.team.ahachul_backend.api.common.adapter.`in`
 import backend.team.ahachul_backend.api.common.adapter.`in`.dto.SearchSubwayLineDto
 import backend.team.ahachul_backend.api.common.application.port.`in`.SubwayLineUseCase
 import backend.team.ahachul_backend.common.response.CommonResponse
-import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
 

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/common/adapter/in/dto/SearchSubwayLineDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/common/adapter/in/dto/SearchSubwayLineDto.kt
@@ -1,29 +1,24 @@
 package backend.team.ahachul_backend.api.common.adapter.`in`.dto
 
 import backend.team.ahachul_backend.common.domain.entity.SubwayLineEntity
-import java.io.Serializable
+import com.fasterxml.jackson.annotation.JsonProperty
 
 class SearchSubwayLineDto {
 
     data class Response(
-        val subwayLines: List<SubwayLine>
-    ): Serializable {
-        companion object {
-            private const val serialVersionUID: Long = -4129628067395047900L
-        }
-    }
+        @JsonProperty("subwayLines") val subwayLines: List<SubwayLine>
+    )
 }
 
 
 data class SubwayLine(
-    val id: Long,
-    val name: String,
-    val phoneNumber: String,
-    val stations: List<Station>
-): Serializable {
+    @JsonProperty("id") val id: Long,
+    @JsonProperty("name") val name: String,
+    @JsonProperty("phoneNumber") val phoneNumber: String,
+    @JsonProperty("stations") val stations: List<Station>
+) {
 
     companion object {
-        private const val serialVersionUID: Long = -5129628457305047900L
 
         fun of(subwayLine: SubwayLineEntity, stations: List<Station>): SubwayLine {
             return SubwayLine(
@@ -37,10 +32,6 @@ data class SubwayLine(
 }
 
 data class Station(
-    val id: Long,
-    val name: String
-): Serializable {
-    companion object {
-        private const val serialVersionUID: Long = -3129628467395847900L
-    }
-}
+    @JsonProperty("id") val id: Long,
+    @JsonProperty("name") val name: String
+)

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/config/RedisConfig.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/config/RedisConfig.kt
@@ -3,10 +3,15 @@ package backend.team.ahachul_backend.common.config
 import backend.team.ahachul_backend.common.properties.RedisProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager
 import org.springframework.data.redis.connection.RedisConnectionFactory
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
 import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.RedisSerializationContext
+import org.springframework.data.redis.serializer.StringRedisSerializer
 
 @Configuration
 class RedisConfig(
@@ -25,5 +30,23 @@ class RedisConfig(
         val stringRedisTemplate = StringRedisTemplate()
         stringRedisTemplate.setConnectionFactory(redisConnectionFactory())
         return stringRedisTemplate
+    }
+
+    @Bean
+    fun redisCacheManager(redisConnectionFactory: RedisConnectionFactory): RedisCacheManager {
+        val configuration = RedisCacheConfiguration.defaultCacheConfig()
+            .disableCachingNullValues()
+            .serializeKeysWith(
+                RedisSerializationContext.SerializationPair
+                    .fromSerializer(StringRedisSerializer()))
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair
+                    .fromSerializer(GenericJackson2JsonRedisSerializer())
+            )
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+            .fromConnectionFactory(redisConnectionFactory)
+            .cacheDefaults(configuration)
+            .build()
     }
 }

--- a/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/community/application/service/CommunityCommentServiceTest.kt
+++ b/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/community/application/service/CommunityCommentServiceTest.kt
@@ -21,7 +21,6 @@ import backend.team.ahachul_backend.common.persistence.SubwayLineRepository
 import backend.team.ahachul_backend.common.utils.RequestUtils
 import backend.team.ahachul_backend.config.controller.CommonServiceTestConfig
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test


### PR DESCRIPTION
## 📚 개요
+ #177 

## ✏️ 작업 내용
+ `GenericJackson2JsonRedisSerializer` 로 수정

## 💡 주의 사항
+ 휴 드뎌 성공했습니다 Json 파싱 관련 에러는 커스텀 `objectMapper` 추가해준게 문제였더라구요
+ 그때 로컬 레디스에 저장 안되는거 도커 컨테이너 포기하고 `redis-server` 따로 깔아서 해결했습니다
