### PR TITLE
:bug: 힙 메모리 초과 예외 해결 (#186)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - feature/186
       
 env:
   ECR_REGISTRY: ${{ secrets.AWS_ECR_REGISTRY }}

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/rank/application/service/HashTagRankService.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/rank/application/service/HashTagRankService.kt
@@ -8,8 +8,9 @@ import org.springframework.stereotype.Service
 class HashTagRankService(
     val redisClient: RedisClient
 ){
-
+    
     fun increaseCount(hashTagName: String) {
+        val key: String = KEY + hashTagName
         val setOperations = redisClient.getZSetOps()
         setOperations.incrementScore(KEY, hashTagName, INCREASE_CNT.toDouble())
     }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/response/ResponseCode.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/response/ResponseCode.kt
@@ -44,4 +44,7 @@ enum class ResponseCode(
     NOT_EXIST_ARRIVAL_TRAIN("701", "열차 도착 정보가 없습니다.", HttpStatus.BAD_REQUEST),
     INVALID_SUBWAY_LINE("702", "지원하지 않는 호선입니다.", HttpStatus.BAD_REQUEST),
     INVALID_TRAIN_NO("703", "현재 운행하지 않는 열차 번호입니다.", HttpStatus.BAD_REQUEST),
+
+    // FILE
+    FILE_READ_FAILED("800", "파일 읽기에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/utils/FileUtils.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/utils/FileUtils.kt
@@ -1,28 +1,32 @@
 package backend.team.ahachul_backend.common.utils
 
 import backend.team.ahachul_backend.common.exception.CommonException
+import backend.team.ahachul_backend.common.logging.Logger
 import backend.team.ahachul_backend.common.response.ResponseCode
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.exc.MismatchedInputException
 import org.springframework.stereotype.Component
 import java.io.FileReader
 import java.io.IOException
 
 @Component
-class FileUtils {
+object FileUtils {
 
-    companion object {
-        val objectMapper = ObjectMapper()
+    val logger = Logger(javaClass)
+    val objectMapper = ObjectMapper()
 
-        inline fun <reified T: Any> readFileData(readPath: String): T = run {
-            try {
-                FileReader(readPath).use {
-                    val typeRef = object : TypeReference<T>() {}
-                    return objectMapper.readValue(it, typeRef)
-                }
-            } catch (e: IOException) {
-                throw CommonException(ResponseCode.INTERNAL_SERVER_ERROR, e)
+    inline fun <reified T: Any> readFileData(readPath: String): T? = run {
+        try {
+            FileReader(readPath).use {
+                val typeRef = object : TypeReference<T>() {}
+                return objectMapper.readValue(it, typeRef)
             }
+        } catch (e: MismatchedInputException) {
+            logger.info("no data to read from file : $readPath")
+            return null
+        } catch (e: IOException) {
+            throw CommonException(ResponseCode.FILE_READ_FAILED, e)
         }
     }
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/schedule/config/ScheduleConfig.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/schedule/config/ScheduleConfig.kt
@@ -43,7 +43,7 @@ class ScheduleConfig(
         val jobDataMap = JobDataMap()
         jobDataMap.put("EXECUTION_COUNT", 0)
         jobDataMap.put("MAX_RETRY_COUNT", 3)
-        jobDataMap.put("FILE_READ_PATH", "/home/all.json")
+        jobDataMap.put("FILE_READ_PATH", "/home/")
         return jobDataMap
     }
 

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/schedule/config/ScheduleConfig.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/schedule/config/ScheduleConfig.kt
@@ -52,7 +52,7 @@ class ScheduleConfig(
             .withIdentity(TriggerKey("UPDATE_LOST_DATA_TRIGGER ", "LOST"))
             .startNow()
             .withSchedule(
-                CronScheduleBuilder.cronSchedule("30 24 * ? * *")
+                CronScheduleBuilder.cronSchedule("0 7 * ? * *")
                     .withMisfireHandlingInstructionFireAndProceed()
             )
             .build()

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/schedule/config/ScheduleConfig.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/schedule/config/ScheduleConfig.kt
@@ -52,7 +52,7 @@ class ScheduleConfig(
             .withIdentity(TriggerKey("UPDATE_LOST_DATA_TRIGGER ", "LOST"))
             .startNow()
             .withSchedule(
-                CronScheduleBuilder.cronSchedule("0 7 * ? * *")
+                CronScheduleBuilder.cronSchedule("0 10 * ? * *")
                     .withMisfireHandlingInstructionFireAndProceed()
             )
             .build()

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/schedule/job/UpdateLostDataJob.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/schedule/job/UpdateLostDataJob.kt
@@ -23,8 +23,12 @@ class UpdateLostDataJob(
     override fun executeInternal(context: JobExecutionContext) {
         val jobDataMap = context.jobDetail.jobDataMap
         val fileReadPath = jobDataMap.getString("FILE_READ_PATH")
-        val response = FileUtils.readFileData<List<Map<String, Lost112Data>>>(fileReadPath)
-        saveLostPosts(response)
+
+        for (i: Int in 1 .. 10) {
+            val fileFullReadPath = "$fileReadPath$i.json"
+            val response = FileUtils.readFileData<List<Map<String, Lost112Data>>>(fileFullReadPath)
+            response?.let { saveLostPosts(it) }
+        }
     }
 
     private fun saveLostPosts(response: List<Map<String, Lost112Data>>) {

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/schedule/job/UpdateLostDataJob.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/schedule/job/UpdateLostDataJob.kt
@@ -4,6 +4,7 @@ import backend.team.ahachul_backend.api.lost.application.port.out.LostPostWriter
 import backend.team.ahachul_backend.api.lost.domain.entity.CategoryEntity
 import backend.team.ahachul_backend.api.lost.domain.entity.LostPostEntity
 import backend.team.ahachul_backend.common.domain.entity.SubwayLineEntity
+import backend.team.ahachul_backend.common.logging.Logger
 import backend.team.ahachul_backend.common.storage.CategoryStorage
 import backend.team.ahachul_backend.common.storage.SubwayLineStorage
 import backend.team.ahachul_backend.common.utils.FileUtils
@@ -20,6 +21,8 @@ class UpdateLostDataJob(
     private val categoryStorage: CategoryStorage
 ): QuartzJobBean() {
 
+    val logger = Logger(javaClass)
+
     override fun executeInternal(context: JobExecutionContext) {
         val jobDataMap = context.jobDetail.jobDataMap
         val fileReadPath = jobDataMap.getString("FILE_READ_PATH")
@@ -27,7 +30,11 @@ class UpdateLostDataJob(
         for (i: Int in 1 .. 10) {
             val fileFullReadPath = "$fileReadPath$i.json"
             val response = FileUtils.readFileData<List<Map<String, Lost112Data>>>(fileFullReadPath)
-            response?.let { saveLostPosts(it) }
+            response?.let {
+                val totalCount = response.size
+                saveLostPosts(it)
+                logger.info("$totalCount 개의 유실물이 $fileFullReadPath 파일에서 수집되었습니다.")
+            }
         }
     }
 

--- a/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/rank/application/service/HashTagRankServiceTest.kt
+++ b/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/rank/application/service/HashTagRankServiceTest.kt
@@ -81,10 +81,10 @@ class HashTagRankServiceTest(
     @Test
     fun 조회수_증가_동시성_테스트() {
         val hashTagName = "1호선"
-        val executorService: ExecutorService = Executors.newFixedThreadPool(10)
-        val countDownLatch = CountDownLatch(10)
+        val executorService: ExecutorService = Executors.newFixedThreadPool(100)
+        val countDownLatch = CountDownLatch(100)
 
-        for (i in 1..10) {
+        for (i in 1..100) {
             executorService.execute {
                 hashTagRankService.increaseCount(hashTagName)
                 countDownLatch.countDown()
@@ -93,6 +93,6 @@ class HashTagRankServiceTest(
 
         countDownLatch.await()
         val result = hashTagRankService.get(hashTagName)
-        assertThat(result).isEqualTo(10.0)
+        assertThat(result).isEqualTo(100.0)
     }
 }


### PR DESCRIPTION
## 📚 개요
+ #186 

## ✏️ 작업 내용
+ DB 바뀐 후 데이터가 다 날라갔고, Lostt112 모든 데이터가 들어있는 파일을 다시 읽어오는 과정에서 힙 메모리 초과 에러가 났습니다.
+ 데이터 분석쪽이랑 상의했고, 파일 10개로 나눠서 데이터를 수집하기로 했습니다.

## 💡 주의 사항
+ 데이터가 수집될 때 중복으로 들어오고 있는 것 같아서, 이 부분은 찬우님이 다시 확인해주신다고 합니당
+ 만약 중복이 해결되면 하루에 수집되는 데이터가 좀 줄어들텐데, 굳이 10개로 나눠놓았으니 bulk insert 한 효과가 없을 것 같기도 하네요.
+ 그래서 생각해본 방법이 "힙이 감당할 정도의 사이즈 이상을 넘어가면 파일을 10개로 나누고, 아니면 한 파일로 수집한다" 입니다. 하지만 그 기준 정하기가 애매할 것 같은데 어떻게 생각하시나요. 좋은 대안이 있을까요?🤔
