### PR TITLE
:sparkles: 역 즐겨찾기 및 조회 구현 (#188)

### DIFF
--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/common/application/port/out/StationPersistence.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/common/application/port/out/StationPersistence.kt
@@ -16,4 +16,10 @@ class StationPersistence(
             throw AdapterException(ResponseCode.INVALID_DOMAIN)
         }
     }
+
+    override fun getByName(name: String): StationEntity {
+        return stationRepository.findByName(name).orElseThrow {
+            throw AdapterException(ResponseCode.INVALID_DOMAIN)
+        }
+    }
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/common/application/port/out/StationReader.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/common/application/port/out/StationReader.kt
@@ -6,4 +6,6 @@ import backend.team.ahachul_backend.common.domain.entity.SubwayLineEntity
 interface StationReader {
 
     fun getById(id: Long): StationEntity
+
+    fun getByName(name: String): StationEntity
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/common/application/port/out/StationRepository.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/common/application/port/out/StationRepository.kt
@@ -3,7 +3,10 @@ package backend.team.ahachul_backend.api.common.application.port.out
 import backend.team.ahachul_backend.api.common.domain.entity.StationEntity
 import backend.team.ahachul_backend.common.domain.entity.SubwayLineEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import java.util.*
 
 interface StationRepository: JpaRepository<StationEntity, Long> {
+
+    fun findByName(name: String): Optional<StationEntity>
 
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/common/application/port/out/SubwayLineStationPersistence.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/common/application/port/out/SubwayLineStationPersistence.kt
@@ -1,5 +1,6 @@
 package backend.team.ahachul_backend.api.common.application.port.out
 
+import backend.team.ahachul_backend.api.common.domain.entity.StationEntity
 import backend.team.ahachul_backend.api.common.domain.entity.SubwayLineStationEntity
 import org.springframework.stereotype.Component
 
@@ -7,6 +8,10 @@ import org.springframework.stereotype.Component
 class SubwayLineStationPersistence(
     private val subwayLineStationRepository: SubwayLineStationRepository
 ): SubwayLineStationReader {
+
+    override fun findByStation(station: StationEntity): List<SubwayLineStationEntity> {
+        return subwayLineStationRepository.findByStation(station)
+    }
 
     override fun findAll(): List<SubwayLineStationEntity> {
         return subwayLineStationRepository.findAll()

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/common/application/port/out/SubwayLineStationReader.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/common/application/port/out/SubwayLineStationReader.kt
@@ -1,8 +1,13 @@
 package backend.team.ahachul_backend.api.common.application.port.out
 
+import backend.team.ahachul_backend.api.common.domain.entity.StationEntity
 import backend.team.ahachul_backend.api.common.domain.entity.SubwayLineStationEntity
+import org.springframework.data.jpa.repository.EntityGraph
 
 interface SubwayLineStationReader {
+
+    @EntityGraph(attributePaths = ["subwayLine"])
+    fun findByStation(station: StationEntity): List<SubwayLineStationEntity>
 
     fun findAll(): List<SubwayLineStationEntity>
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/common/application/port/out/SubwayLineStationReader.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/common/application/port/out/SubwayLineStationReader.kt
@@ -2,11 +2,9 @@ package backend.team.ahachul_backend.api.common.application.port.out
 
 import backend.team.ahachul_backend.api.common.domain.entity.StationEntity
 import backend.team.ahachul_backend.api.common.domain.entity.SubwayLineStationEntity
-import org.springframework.data.jpa.repository.EntityGraph
 
 interface SubwayLineStationReader {
 
-    @EntityGraph(attributePaths = ["subwayLine"])
     fun findByStation(station: StationEntity): List<SubwayLineStationEntity>
 
     fun findAll(): List<SubwayLineStationEntity>

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/common/application/port/out/SubwayLineStationRepository.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/common/application/port/out/SubwayLineStationRepository.kt
@@ -1,5 +1,6 @@
 package backend.team.ahachul_backend.api.common.application.port.out
 
+import backend.team.ahachul_backend.api.common.domain.entity.StationEntity
 import backend.team.ahachul_backend.api.common.domain.entity.SubwayLineStationEntity
 import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
@@ -8,4 +9,7 @@ interface SubwayLineStationRepository: JpaRepository<SubwayLineStationEntity, Lo
 
     @EntityGraph(attributePaths = ["station", "subwayLine"])
     override fun findAll(): List<SubwayLineStationEntity>
+
+//    @EntityGraph(attributePaths = ["station", "subwayLine"])
+    fun findByStation(station: StationEntity): List<SubwayLineStationEntity>
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/common/application/port/out/SubwayLineStationRepository.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/common/application/port/out/SubwayLineStationRepository.kt
@@ -10,6 +10,6 @@ interface SubwayLineStationRepository: JpaRepository<SubwayLineStationEntity, Lo
     @EntityGraph(attributePaths = ["station", "subwayLine"])
     override fun findAll(): List<SubwayLineStationEntity>
 
-//    @EntityGraph(attributePaths = ["station", "subwayLine"])
+    @EntityGraph(attributePaths = ["subwayLine"])
     fun findByStation(station: StationEntity): List<SubwayLineStationEntity>
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/MemberController.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/MemberController.kt
@@ -36,14 +36,14 @@ class MemberController(
         return CommonResponse.success(memberUseCase.checkNickname(request.toCommand()))
     }
 
-    @PostMapping("/v1/members/stations")
+    @PostMapping("/v1/members/bookmarks/stations")
     fun bookmarkStation(
             @RequestBody request: BookmarkStationDto.Request
     ): CommonResponse<BookmarkStationDto.Response> {
         return CommonResponse.success(memberUseCase.bookmarkStation(request.toCommand()))
     }
 
-    @GetMapping("/v1/members/stations")
+    @GetMapping("/v1/members/bookmarks/stations")
     fun getBookmarkStation(): CommonResponse<GetBookmarkStationDto.Response> {
         return CommonResponse.success(memberUseCase.getBookmarkStation())
     }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/MemberController.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/MemberController.kt
@@ -1,5 +1,6 @@
 package backend.team.ahachul_backend.api.member.adapter.web.`in`
 
+import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.BookmarkStationDto
 import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.CheckNicknameDto
 import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.GetMemberDto
 import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.UpdateMemberDto
@@ -25,12 +26,23 @@ class MemberController(
 
     @Authentication
     @PatchMapping("/v1/members")
-    fun updateMember(@RequestBody request: UpdateMemberDto.Request): CommonResponse<UpdateMemberDto.Response> {
+    fun updateMember(
+            @RequestBody request: UpdateMemberDto.Request
+    ): CommonResponse<UpdateMemberDto.Response> {
         return CommonResponse.success(memberUseCase.updateMember(request.toCommand()))
     }
 
     @PostMapping("/v1/members/check-nickname")
-    fun checkNickname(@RequestBody request: CheckNicknameDto.Request): CommonResponse<CheckNicknameDto.Response> {
+    fun checkNickname(
+            @RequestBody request: CheckNicknameDto.Request
+    ): CommonResponse<CheckNicknameDto.Response> {
         return CommonResponse.success(memberUseCase.checkNickname(request.toCommand()))
+    }
+
+    @PostMapping("/v1/members/stations")
+    fun bookmarkStation(
+            @RequestBody request: BookmarkStationDto.Request
+    ): CommonResponse<BookmarkStationDto.Response> {
+        return CommonResponse.success(memberUseCase.bookmarkStation(request.toCommand()))
     }
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/MemberController.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/MemberController.kt
@@ -1,9 +1,6 @@
 package backend.team.ahachul_backend.api.member.adapter.web.`in`
 
-import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.BookmarkStationDto
-import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.CheckNicknameDto
-import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.GetMemberDto
-import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.UpdateMemberDto
+import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.*
 import backend.team.ahachul_backend.api.member.application.port.`in`.MemberUseCase
 import backend.team.ahachul_backend.common.annotation.Authentication
 import backend.team.ahachul_backend.common.response.CommonResponse
@@ -44,5 +41,10 @@ class MemberController(
             @RequestBody request: BookmarkStationDto.Request
     ): CommonResponse<BookmarkStationDto.Response> {
         return CommonResponse.success(memberUseCase.bookmarkStation(request.toCommand()))
+    }
+
+    @GetMapping("/v1/members/stations")
+    fun getBookmarkStation(): CommonResponse<GetBookmarkStationDto.Response> {
+        return CommonResponse.success(memberUseCase.getBookmarkStation())
     }
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/dto/BookmarkStationDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/dto/BookmarkStationDto.kt
@@ -1,0 +1,20 @@
+package backend.team.ahachul_backend.api.member.adapter.web.`in`.dto
+
+import backend.team.ahachul_backend.api.member.application.port.`in`.command.BookmarkStationCommand
+
+class BookmarkStationDto {
+
+    data class Request(
+        val stationNames: List<String>
+    ) {
+        fun toCommand(): BookmarkStationCommand {
+            return BookmarkStationCommand(
+                stationNames = stationNames
+            )
+        }
+    }
+
+    data class Response(
+        val memberStationIds: List<Long>
+    )
+}

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/dto/BookmarkStationDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/dto/BookmarkStationDto.kt
@@ -9,7 +9,7 @@ class BookmarkStationDto {
     ) {
         fun toCommand(): BookmarkStationCommand {
             return BookmarkStationCommand(
-                stationNames = stationNames
+                stationNames = stationNames.toMutableList()
             )
         }
     }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/dto/GetBookmarkStationDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/dto/GetBookmarkStationDto.kt
@@ -1,0 +1,19 @@
+package backend.team.ahachul_backend.api.member.adapter.web.`in`.dto
+
+class GetBookmarkStationDto {
+
+    data class Response(
+        val stationInfoList: List<StationInfo>
+    )
+
+    data class StationInfo(
+        val stationId: Long,
+        val stationName: String,
+        val subwayLineInfoList: List<SubwayLineInfo>
+    )
+
+    data class SubwayLineInfo(
+        val subwayLineId: Long,
+        val subwayLineName: String
+    )
+}

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/out/MemberStationPersistence.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/out/MemberStationPersistence.kt
@@ -1,5 +1,6 @@
 package backend.team.ahachul_backend.api.member.adapter.web.out
 
+import backend.team.ahachul_backend.api.member.application.port.out.MemberStationReader
 import backend.team.ahachul_backend.api.member.application.port.out.MemberStationWriter
 import backend.team.ahachul_backend.api.member.domain.entity.MemberEntity
 import backend.team.ahachul_backend.api.member.domain.entity.MemberStationEntity
@@ -8,7 +9,7 @@ import org.springframework.stereotype.Component
 @Component
 class MemberStationPersistence (
     private val memberStationRepository: MemberStationRepository
-): MemberStationWriter {
+): MemberStationReader, MemberStationWriter {
 
     override fun deleteByMember(member: MemberEntity) {
         memberStationRepository.deleteAllByMember(member)
@@ -16,6 +17,10 @@ class MemberStationPersistence (
 
     override fun save(entity: MemberStationEntity): MemberStationEntity {
         return memberStationRepository.save(entity)
+    }
+
+    override fun getByMember(member: MemberEntity): List<MemberStationEntity> {
+        return memberStationRepository.findAllByMember(member)
     }
 
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/out/MemberStationPersistence.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/out/MemberStationPersistence.kt
@@ -1,0 +1,21 @@
+package backend.team.ahachul_backend.api.member.adapter.web.out
+
+import backend.team.ahachul_backend.api.member.application.port.out.MemberStationWriter
+import backend.team.ahachul_backend.api.member.domain.entity.MemberEntity
+import backend.team.ahachul_backend.api.member.domain.entity.MemberStationEntity
+import org.springframework.stereotype.Component
+
+@Component
+class MemberStationPersistence (
+    private val memberStationRepository: MemberStationRepository
+): MemberStationWriter {
+
+    override fun deleteByMember(member: MemberEntity) {
+        memberStationRepository.deleteAllByMember(member)
+    }
+
+    override fun save(entity: MemberStationEntity): MemberStationEntity {
+        return memberStationRepository.save(entity)
+    }
+
+}

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/out/MemberStationPersistence.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/out/MemberStationPersistence.kt
@@ -11,8 +11,8 @@ class MemberStationPersistence (
     private val memberStationRepository: MemberStationRepository
 ): MemberStationReader, MemberStationWriter {
 
-    override fun deleteByMember(member: MemberEntity) {
-        memberStationRepository.deleteAllByMember(member)
+    override fun delete(id: Long) {
+        memberStationRepository.deleteById(id)
     }
 
     override fun save(entity: MemberStationEntity): MemberStationEntity {

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/out/MemberStationRepository.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/out/MemberStationRepository.kt
@@ -2,9 +2,13 @@ package backend.team.ahachul_backend.api.member.adapter.web.out
 
 import backend.team.ahachul_backend.api.member.domain.entity.MemberEntity
 import backend.team.ahachul_backend.api.member.domain.entity.MemberStationEntity
+import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface MemberStationRepository: JpaRepository<MemberStationEntity, Long> {
 
     fun deleteAllByMember(member: MemberEntity)
+
+    @EntityGraph(attributePaths = ["station"])
+    fun findAllByMember(member: MemberEntity): List<MemberStationEntity>
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/out/MemberStationRepository.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/out/MemberStationRepository.kt
@@ -1,0 +1,10 @@
+package backend.team.ahachul_backend.api.member.adapter.web.out
+
+import backend.team.ahachul_backend.api.member.domain.entity.MemberEntity
+import backend.team.ahachul_backend.api.member.domain.entity.MemberStationEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MemberStationRepository: JpaRepository<MemberStationEntity, Long> {
+
+    fun deleteAllByMember(member: MemberEntity)
+}

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/in/MemberUseCase.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/in/MemberUseCase.kt
@@ -1,9 +1,6 @@
 package backend.team.ahachul_backend.api.member.application.port.`in`
 
-import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.BookmarkStationDto
-import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.CheckNicknameDto
-import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.GetMemberDto
-import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.UpdateMemberDto
+import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.*
 import backend.team.ahachul_backend.api.member.application.port.`in`.command.BookmarkStationCommand
 import backend.team.ahachul_backend.api.member.application.port.`in`.command.CheckNicknameCommand
 import backend.team.ahachul_backend.api.member.application.port.`in`.command.UpdateMemberCommand
@@ -17,4 +14,6 @@ interface MemberUseCase {
     fun checkNickname(command: CheckNicknameCommand): CheckNicknameDto.Response
 
     fun bookmarkStation(command: BookmarkStationCommand): BookmarkStationDto.Response
+
+    fun getBookmarkStation(): GetBookmarkStationDto.Response
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/in/MemberUseCase.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/in/MemberUseCase.kt
@@ -1,8 +1,10 @@
 package backend.team.ahachul_backend.api.member.application.port.`in`
 
+import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.BookmarkStationDto
 import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.CheckNicknameDto
 import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.GetMemberDto
 import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.UpdateMemberDto
+import backend.team.ahachul_backend.api.member.application.port.`in`.command.BookmarkStationCommand
 import backend.team.ahachul_backend.api.member.application.port.`in`.command.CheckNicknameCommand
 import backend.team.ahachul_backend.api.member.application.port.`in`.command.UpdateMemberCommand
 
@@ -13,4 +15,6 @@ interface MemberUseCase {
     fun updateMember(command: UpdateMemberCommand): UpdateMemberDto.Response
 
     fun checkNickname(command: CheckNicknameCommand): CheckNicknameDto.Response
+
+    fun bookmarkStation(command: BookmarkStationCommand): BookmarkStationDto.Response
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/in/command/BookmarkStationCommand.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/in/command/BookmarkStationCommand.kt
@@ -1,0 +1,5 @@
+package backend.team.ahachul_backend.api.member.application.port.`in`.command
+
+data class BookmarkStationCommand(
+    val stationNames: List<String>
+)

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/in/command/BookmarkStationCommand.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/in/command/BookmarkStationCommand.kt
@@ -1,5 +1,18 @@
 package backend.team.ahachul_backend.api.member.application.port.`in`.command
 
+import backend.team.ahachul_backend.common.exception.BusinessException
+import backend.team.ahachul_backend.common.response.ResponseCode
+
 data class BookmarkStationCommand(
-    val stationNames: List<String>
-)
+    val stationNames: MutableList<String>
+) {
+    init {
+        if (stationNames.size > MAX_STATION_COUNT) {
+            throw BusinessException(ResponseCode.EXCEED_MAXIMUM_STATION_COUNT)
+        }
+    }
+
+    companion object {
+        const val MAX_STATION_COUNT = 3
+    }
+}

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/out/MemberStationReader.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/out/MemberStationReader.kt
@@ -1,0 +1,9 @@
+package backend.team.ahachul_backend.api.member.application.port.out
+
+import backend.team.ahachul_backend.api.member.domain.entity.MemberEntity
+import backend.team.ahachul_backend.api.member.domain.entity.MemberStationEntity
+
+interface MemberStationReader {
+
+    fun getByMember(member: MemberEntity): List<MemberStationEntity>
+}

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/out/MemberStationWriter.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/out/MemberStationWriter.kt
@@ -1,11 +1,10 @@
 package backend.team.ahachul_backend.api.member.application.port.out
 
-import backend.team.ahachul_backend.api.member.domain.entity.MemberEntity
 import backend.team.ahachul_backend.api.member.domain.entity.MemberStationEntity
 
 interface MemberStationWriter {
 
-    fun deleteByMember(member: MemberEntity)
+    fun delete(id: Long)
 
     fun save(entity: MemberStationEntity): MemberStationEntity
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/out/MemberStationWriter.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/out/MemberStationWriter.kt
@@ -1,0 +1,11 @@
+package backend.team.ahachul_backend.api.member.application.port.out
+
+import backend.team.ahachul_backend.api.member.domain.entity.MemberEntity
+import backend.team.ahachul_backend.api.member.domain.entity.MemberStationEntity
+
+interface MemberStationWriter {
+
+    fun deleteByMember(member: MemberEntity)
+
+    fun save(entity: MemberStationEntity): MemberStationEntity
+}

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/service/MemberService.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/service/MemberService.kt
@@ -1,12 +1,19 @@
 package backend.team.ahachul_backend.api.member.application.service
 
+import backend.team.ahachul_backend.api.common.application.port.out.StationReader
+import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.BookmarkStationDto
 import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.CheckNicknameDto
 import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.GetMemberDto
 import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.UpdateMemberDto
 import backend.team.ahachul_backend.api.member.application.port.`in`.MemberUseCase
+import backend.team.ahachul_backend.api.member.application.port.`in`.command.BookmarkStationCommand
 import backend.team.ahachul_backend.api.member.application.port.`in`.command.CheckNicknameCommand
 import backend.team.ahachul_backend.api.member.application.port.`in`.command.UpdateMemberCommand
 import backend.team.ahachul_backend.api.member.application.port.out.MemberReader
+import backend.team.ahachul_backend.api.member.application.port.out.MemberStationWriter
+import backend.team.ahachul_backend.api.member.domain.entity.MemberStationEntity
+import backend.team.ahachul_backend.common.exception.BusinessException
+import backend.team.ahachul_backend.common.response.ResponseCode
 import backend.team.ahachul_backend.common.utils.RequestUtils
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -14,7 +21,9 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 @Transactional(readOnly = true)
 class MemberService(
-        private val memberReader: MemberReader
+    private val memberReader: MemberReader,
+    private val stationReader: StationReader,
+    private val memberStationWriter: MemberStationWriter
 ) : MemberUseCase {
 
     override fun getMember(): GetMemberDto.Response {
@@ -39,6 +48,23 @@ class MemberService(
         return CheckNicknameDto.Response.of(
             available = !memberReader.existMember(command.nickname)
         )
+    }
+
+    override fun bookmarkStation(command: BookmarkStationCommand): BookmarkStationDto.Response {
+        val member = memberReader.getMember(RequestUtils.getAttribute("memberId")!!.toLong())
+        if (command.stationNames.size > 3) {
+            throw BusinessException(ResponseCode.EXCEED_MAXIMUM_STATION_COUNT)
+        }
+
+        memberStationWriter.deleteByMember(member)
+        val bookmarkStationIds = command.stationNames
+                .map { stationReader.getByName(it) }
+                .map {station ->
+                    val memberStation = MemberStationEntity(member = member, station = station)
+                    memberStationWriter.save(memberStation).id
+                }
+
+        return BookmarkStationDto.Response(bookmarkStationIds)
     }
 }
 

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/service/MemberService.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/service/MemberService.kt
@@ -1,15 +1,15 @@
 package backend.team.ahachul_backend.api.member.application.service
 
 import backend.team.ahachul_backend.api.common.application.port.out.StationReader
-import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.BookmarkStationDto
-import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.CheckNicknameDto
-import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.GetMemberDto
-import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.UpdateMemberDto
+import backend.team.ahachul_backend.api.common.application.port.out.SubwayLineStationReader
+import backend.team.ahachul_backend.api.common.domain.entity.StationEntity
+import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.*
 import backend.team.ahachul_backend.api.member.application.port.`in`.MemberUseCase
 import backend.team.ahachul_backend.api.member.application.port.`in`.command.BookmarkStationCommand
 import backend.team.ahachul_backend.api.member.application.port.`in`.command.CheckNicknameCommand
 import backend.team.ahachul_backend.api.member.application.port.`in`.command.UpdateMemberCommand
 import backend.team.ahachul_backend.api.member.application.port.out.MemberReader
+import backend.team.ahachul_backend.api.member.application.port.out.MemberStationReader
 import backend.team.ahachul_backend.api.member.application.port.out.MemberStationWriter
 import backend.team.ahachul_backend.api.member.domain.entity.MemberStationEntity
 import backend.team.ahachul_backend.common.exception.BusinessException
@@ -23,7 +23,9 @@ import org.springframework.transaction.annotation.Transactional
 class MemberService(
     private val memberReader: MemberReader,
     private val stationReader: StationReader,
-    private val memberStationWriter: MemberStationWriter
+    private val memberStationWriter: MemberStationWriter,
+    private val memberStationReader: MemberStationReader,
+    private val subwayLineStationReader: SubwayLineStationReader
 ) : MemberUseCase {
 
     override fun getMember(): GetMemberDto.Response {
@@ -50,21 +52,53 @@ class MemberService(
         )
     }
 
+    @Transactional
     override fun bookmarkStation(command: BookmarkStationCommand): BookmarkStationDto.Response {
         val member = memberReader.getMember(RequestUtils.getAttribute("memberId")!!.toLong())
+
         if (command.stationNames.size > 3) {
             throw BusinessException(ResponseCode.EXCEED_MAXIMUM_STATION_COUNT)
         }
 
         memberStationWriter.deleteByMember(member)
         val bookmarkStationIds = command.stationNames
-                .map { stationReader.getByName(it) }
-                .map {station ->
-                    val memberStation = MemberStationEntity(member = member, station = station)
-                    memberStationWriter.save(memberStation).id
-                }
+            .map { stationReader.getByName(it) }
+            .map { station ->
+                val memberStation = MemberStationEntity(
+                        member = member,
+                        station = station
+                )
+                memberStationWriter.save(memberStation).id
+            }
 
         return BookmarkStationDto.Response(bookmarkStationIds)
+    }
+
+    override fun getBookmarkStation(): GetBookmarkStationDto.Response {
+        val member = memberReader.getMember(RequestUtils.getAttribute("memberId")!!.toLong())
+
+        val bookmarkStations = memberStationReader.getByMember(member)
+        val stationInfos = bookmarkStations
+            .map {
+                val station = it.station
+                GetBookmarkStationDto.StationInfo(
+                        stationId = station.id,
+                        stationName = station.name,
+                        subwayLineInfoList = getSubwayLineInfos(station)
+                )
+            }
+
+        return GetBookmarkStationDto.Response(stationInfos)
+    }
+
+    private fun getSubwayLineInfos(station: StationEntity): List<GetBookmarkStationDto.SubwayLineInfo>{
+        val subwayLineStations = subwayLineStationReader.findByStation(station)
+        return subwayLineStations.map {
+            GetBookmarkStationDto.SubwayLineInfo(
+                    subwayLineId = it.subwayLine.id,
+                    subwayLineName = it.subwayLine.name
+            )
+        }
     }
 }
 

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/domain/entity/MemberStationEntity.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/domain/entity/MemberStationEntity.kt
@@ -1,0 +1,24 @@
+package backend.team.ahachul_backend.api.member.domain.entity
+
+import backend.team.ahachul_backend.api.common.domain.entity.StationEntity
+import backend.team.ahachul_backend.common.entity.BaseEntity
+import jakarta.persistence.*
+
+@Entity
+class MemberStationEntity(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_station_id")
+    val id: Long = 0,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    val member: MemberEntity,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "station_id")
+    val station: StationEntity
+
+): BaseEntity() {
+}

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/response/ResponseCode.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/response/ResponseCode.kt
@@ -44,4 +44,7 @@ enum class ResponseCode(
     NOT_EXIST_ARRIVAL_TRAIN("701", "열차 도착 정보가 없습니다.", HttpStatus.BAD_REQUEST),
     INVALID_SUBWAY_LINE("702", "지원하지 않는 호선입니다.", HttpStatus.BAD_REQUEST),
     INVALID_TRAIN_NO("703", "현재 운행하지 않는 열차 번호입니다.", HttpStatus.BAD_REQUEST),
+
+    // STATION
+    EXCEED_MAXIMUM_STATION_COUNT("800", "즐겨찾는 역은 최대 3개까지 가능합니다.", HttpStatus.BAD_REQUEST)
 }

--- a/ahachul_backend/src/main/resources/data.sql
+++ b/ahachul_backend/src/main/resources/data.sql
@@ -22,6 +22,35 @@ INSERT INTO tb_category(name) values('기타물품');
 -- # WARNING
 -- Don't touch the contents below.
 
+-- ## 지하철 노선
+
+INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (1, '1호선', 'METROPOLITAN', '02-000-0000', 1001);
+INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (2, '2호선', 'METROPOLITAN', '02-000-0000', 1002);
+INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (3, '3호선', 'METROPOLITAN', '02-000-0000', 1003);
+INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (4, '4호선', 'METROPOLITAN', '02-000-0000', 1004);
+INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (5, '5호선', 'METROPOLITAN', '02-000-0000', 1005);
+INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (6, '6호선', 'METROPOLITAN', '02-000-0000', 1006);
+INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (7, '7호선', 'METROPOLITAN', '02-000-0000', 1007);
+INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (8, '8호선', 'METROPOLITAN', '02-000-0000', 1008);
+INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (9, '9호선', 'METROPOLITAN', '02-000-0000', 1009);
+INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (10, '경강선', 'METROPOLITAN', '02-000-0000', 1081);
+INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (11, '경의중앙선', 'METROPOLITAN', '02-000-0000', 1063);
+INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (12, '경춘선', 'METROPOLITAN', '02-000-0000', 1067);
+INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (13, '공항철도', 'METROPOLITAN', '02-000-0000', 1065);
+INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (15, '서해선', 'METROPOLITAN', '02-000-0000', 1093);
+INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (16, '수인분당선', 'METROPOLITAN', '02-000-0000', 1075);
+INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (18, '신분당선', 'METROPOLITAN', '02-000-0000', 1077);
+INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (20, '우이신설경전철', 'METROPOLITAN', '02-000-0000', 1092);
+
+-- ### 제외 데이터
+-- INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (14, '김포도시철도', 'METROPOLITAN', '02-000-0000');
+-- INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (17, '신림선', 'METROPOLITAN', '02-000-0000');
+-- INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (19, '용인경전철', 'METROPOLITAN', '02-000-0000');
+-- INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (21, '의정부경전철', 'METROPOLITAN', '02-000-0000');
+-- INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (22, '인천2호선', 'METROPOLITAN', '02-000-0000');
+-- INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity VALUES (23, '인천선', 'METROPOLITAN', '02-000-0000');
+
+
 -- ## 지하철 번호
 
 -- # 1호선
@@ -78,34 +107,6 @@ INSERT INTO tb_train(prefix_train_no, subway_line_id) values('331', 11);
 
 -- # 우이신설선
 INSERT INTO tb_train(prefix_train_no, subway_line_id) values('UL', 20);
-
--- ## 지하철 노선
-
-INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (1, '1호선', 'METROPOLITAN', '02-000-0000', 1001);
-INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (2, '2호선', 'METROPOLITAN', '02-000-0000', 1002);
-INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (3, '3호선', 'METROPOLITAN', '02-000-0000', 1003);
-INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (4, '4호선', 'METROPOLITAN', '02-000-0000', 1004);
-INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (5, '5호선', 'METROPOLITAN', '02-000-0000', 1005);
-INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (6, '6호선', 'METROPOLITAN', '02-000-0000', 1006);
-INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (7, '7호선', 'METROPOLITAN', '02-000-0000', 1007);
-INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (8, '8호선', 'METROPOLITAN', '02-000-0000', 1008);
-INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (9, '9호선', 'METROPOLITAN', '02-000-0000', 1009);
-INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (10, '경강선', 'METROPOLITAN', '02-000-0000', 1081);
-INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (11, '경의중앙선', 'METROPOLITAN', '02-000-0000', 1063);
-INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (12, '경춘선', 'METROPOLITAN', '02-000-0000', 1067);
-INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (13, '공항철도', 'METROPOLITAN', '02-000-0000', 1065);
-INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (15, '서해선', 'METROPOLITAN', '02-000-0000', 1093);
-INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (16, '수인분당선', 'METROPOLITAN', '02-000-0000', 1075);
-INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (18, '신분당선', 'METROPOLITAN', '02-000-0000', 1077);
-INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (20, '우이신설경전철', 'METROPOLITAN', '02-000-0000', 1092);
-
--- ### 제외 데이터
-# INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (14, '김포도시철도', 'METROPOLITAN', '02-000-0000');
-# INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (17, '신림선', 'METROPOLITAN', '02-000-0000');
-# INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (19, '용인경전철', 'METROPOLITAN', '02-000-0000');
-# INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (21, '의정부경전철', 'METROPOLITAN', '02-000-0000');
-# INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity) VALUES (22, '인천2호선', 'METROPOLITAN', '02-000-0000');
-# INSERT INTO tb_subway_line(subway_line_id, name, region_type, phone_number, identity VALUES (23, '인천선', 'METROPOLITAN', '02-000-0000');
 
 -- ## 지하철 노선 정류장
 

--- a/ahachul_backend/src/main/resources/db/migration/V202311271500__add_member_station.sql
+++ b/ahachul_backend/src/main/resources/db/migration/V202311271500__add_member_station.sql
@@ -1,0 +1,11 @@
+CREATE TABLE tb_member_station
+(
+    member_station_id BIGINT NOT NULL auto_increment,
+    member_id      BIGINT NOT NULL,
+    station_id     BIGINT NOT NULL,
+    created_at     TIMESTAMP NOT NULL,
+    created_by     VARCHAR(50) NOT NULL,
+    updated_at     TIMESTAMP NOT NULL,
+    updated_by     VARCHAR(50) NOT NULL,
+    PRIMARY KEY (member_station_id)
+);

--- a/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/MemberControllerDocsTest.kt
+++ b/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/MemberControllerDocsTest.kt
@@ -172,7 +172,7 @@ class MemberControllerDocsTest : CommonDocsTestConfig() {
 
         // when
         val result = mockMvc.perform(
-                post("/v1/members/stations")
+                post("/v1/members/bookmarks/stations")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(request))
                     .accept(MediaType.APPLICATION_JSON)
@@ -219,7 +219,7 @@ class MemberControllerDocsTest : CommonDocsTestConfig() {
 
         // when
         val result = mockMvc.perform(
-                get("/v1/members/stations")
+                get("/v1/members/bookmarks/stations")
                     .accept(MediaType.APPLICATION_JSON)
         )
 

--- a/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/MemberControllerDocsTest.kt
+++ b/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/MemberControllerDocsTest.kt
@@ -1,5 +1,6 @@
 package backend.team.ahachul_backend.api.member.adapter.web.`in`
 
+import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.BookmarkStationDto
 import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.CheckNicknameDto
 import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.GetMemberDto
 import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.UpdateMemberDto
@@ -161,5 +162,40 @@ class MemberControllerDocsTest : CommonDocsTestConfig() {
                     )
                 )
             )
+    }
+
+    @Test
+    fun bookmarkStationTest() {
+        // given
+        val response = BookmarkStationDto.Response(listOf(1L, 2L, 3L))
+        given(memberUseCase.bookmarkStation(any()))
+                .willReturn(response)
+
+        val request = BookmarkStationDto.Request(listOf("발산역", "우장산역", "화곡역"))
+
+        // when
+        val result = mockMvc.perform(
+                post("/v1/members/stations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .accept(MediaType.APPLICATION_JSON)
+        )
+
+        // then
+        result.andExpect(status().isOk)
+                .andDo(
+                        document(
+                                "bookmark-station",
+                                getDocsRequest(),
+                                getDocsResponse(),
+                                requestFields(
+                                        fieldWithPath("stationNames").type(JsonFieldType.ARRAY).description("즐겨찾는 역 이름 리스트"),
+                                ),
+                                responseFields(
+                                        *commonResponseFields(),
+                                        fieldWithPath("result.memberStationIds").type(JsonFieldType.ARRAY).description("즐겨찾는 역 ID 리스트"),
+                                )
+                        )
+                )
     }
 }

--- a/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/MemberControllerDocsTest.kt
+++ b/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/MemberControllerDocsTest.kt
@@ -1,9 +1,6 @@
 package backend.team.ahachul_backend.api.member.adapter.web.`in`
 
-import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.BookmarkStationDto
-import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.CheckNicknameDto
-import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.GetMemberDto
-import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.UpdateMemberDto
+import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.*
 import backend.team.ahachul_backend.api.member.application.port.`in`.MemberUseCase
 import backend.team.ahachul_backend.api.member.domain.model.GenderType
 import backend.team.ahachul_backend.config.controller.CommonDocsTestConfig
@@ -176,26 +173,73 @@ class MemberControllerDocsTest : CommonDocsTestConfig() {
         // when
         val result = mockMvc.perform(
                 post("/v1/members/stations")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request))
-                        .accept(MediaType.APPLICATION_JSON)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+                    .accept(MediaType.APPLICATION_JSON)
         )
 
         // then
         result.andExpect(status().isOk)
-                .andDo(
-                        document(
-                                "bookmark-station",
-                                getDocsRequest(),
-                                getDocsResponse(),
-                                requestFields(
-                                        fieldWithPath("stationNames").type(JsonFieldType.ARRAY).description("즐겨찾는 역 이름 리스트"),
-                                ),
-                                responseFields(
-                                        *commonResponseFields(),
-                                        fieldWithPath("result.memberStationIds").type(JsonFieldType.ARRAY).description("즐겨찾는 역 ID 리스트"),
-                                )
-                        )
+            .andDo(
+                document(
+                    "bookmark-station",
+                    getDocsRequest(),
+                    getDocsResponse(),
+                    requestFields(
+                        fieldWithPath("stationNames").type(JsonFieldType.ARRAY).description("즐겨찾는 역 이름 리스트"),
+                    ),
+                    responseFields(
+                        *commonResponseFields(),
+                        fieldWithPath("result.memberStationIds").type(JsonFieldType.ARRAY).description("즐겨찾는 역 ID 리스트"),
+                    )
                 )
+            )
+    }
+
+    @Test
+    fun getBookmarkStationTest() {
+        // given
+        val response = GetBookmarkStationDto.Response(
+            stationInfoList = listOf(
+                GetBookmarkStationDto.StationInfo(
+                    stationId = 1L,
+                    stationName = "시청역",
+                    subwayLineInfoList = listOf(
+                        GetBookmarkStationDto.SubwayLineInfo(
+                            subwayLineId = 1L,
+                            subwayLineName = "1호선"
+                        )
+                    )
+
+                )
+            )
+        )
+
+        given(memberUseCase.getBookmarkStation()).willReturn(response)
+
+        // when
+        val result = mockMvc.perform(
+                get("/v1/members/stations")
+                    .accept(MediaType.APPLICATION_JSON)
+        )
+
+        // then
+        result.andExpect(status().isOk)
+            .andDo(
+                document(
+                    "get-bookmark-station",
+                    getDocsRequest(),
+                    getDocsResponse(),
+                    responseFields(
+                        *commonResponseFields(),
+                        fieldWithPath("result.stationInfoList").type(JsonFieldType.ARRAY).description("즐겨찾기 한 역 정보 리스트"),
+                        fieldWithPath("result.stationInfoList[].stationId").type(JsonFieldType.NUMBER).description("역 고유 ID"),
+                        fieldWithPath("result.stationInfoList[].stationName").type(JsonFieldType.STRING).description("역 이름"),
+                        fieldWithPath("result.stationInfoList[].subwayLineInfoList").type(JsonFieldType.ARRAY).description("해당 역이 존재하는 노선 리스트"),
+                        fieldWithPath("result.stationInfoList[].subwayLineInfoList[].subwayLineId").type(JsonFieldType.NUMBER).description("노선 고유 ID"),
+                        fieldWithPath("result.stationInfoList[].subwayLineInfoList[].subwayLineName").type(JsonFieldType.STRING).description("노선 이름"),
+                    )
+                )
+            )
     }
 }

--- a/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/member/application/service/MemberServiceTest.kt
+++ b/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/member/application/service/MemberServiceTest.kt
@@ -1,30 +1,56 @@
 package backend.team.ahachul_backend.api.member.application.service
 
+import backend.team.ahachul_backend.api.common.adapter.`in`.dto.SubwayLine
+import backend.team.ahachul_backend.api.common.application.port.out.StationReader
+import backend.team.ahachul_backend.api.common.application.port.out.StationRepository
+import backend.team.ahachul_backend.api.common.application.port.out.SubwayLineStationReader
+import backend.team.ahachul_backend.api.common.application.port.out.SubwayLineStationRepository
+import backend.team.ahachul_backend.api.common.domain.entity.StationEntity
+import backend.team.ahachul_backend.api.common.domain.entity.SubwayLineStationEntity
 import backend.team.ahachul_backend.api.member.adapter.web.out.MemberRepository
+import backend.team.ahachul_backend.api.member.adapter.web.out.MemberStationRepository
 import backend.team.ahachul_backend.api.member.application.port.`in`.MemberUseCase
+import backend.team.ahachul_backend.api.member.application.port.`in`.command.BookmarkStationCommand
 import backend.team.ahachul_backend.api.member.application.port.`in`.command.CheckNicknameCommand
 import backend.team.ahachul_backend.api.member.application.port.`in`.command.UpdateMemberCommand
+import backend.team.ahachul_backend.api.member.application.port.out.MemberStationReader
+import backend.team.ahachul_backend.api.member.application.port.out.MemberStationWriter
 import backend.team.ahachul_backend.api.member.domain.entity.MemberEntity
+import backend.team.ahachul_backend.api.member.domain.entity.MemberStationEntity
 import backend.team.ahachul_backend.api.member.domain.model.GenderType
 import backend.team.ahachul_backend.api.member.domain.model.MemberStatusType
 import backend.team.ahachul_backend.api.member.domain.model.ProviderType
+import backend.team.ahachul_backend.common.domain.entity.SubwayLineEntity
+import backend.team.ahachul_backend.common.exception.BusinessException
+import backend.team.ahachul_backend.common.model.RegionType
+import backend.team.ahachul_backend.common.persistence.SubwayLineRepository
+import backend.team.ahachul_backend.common.response.ResponseCode
 import backend.team.ahachul_backend.common.utils.RequestUtils
 import backend.team.ahachul_backend.config.controller.CommonServiceTestConfig
-import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.annotation.Rollback
 
 class MemberServiceTest(
-        @Autowired val memberRepository: MemberRepository,
-        @Autowired val memberUseCase: MemberUseCase
+    @Autowired val memberRepository: MemberRepository,
+    @Autowired val memberUseCase: MemberUseCase,
+    @Autowired val stationRepository: StationRepository,
+    @Autowired val memberStationRepository: MemberStationRepository,
+    @Autowired val subwayLineStationRepository: SubwayLineStationRepository,
+    @Autowired val subwayLineRepository: SubwayLineRepository
 ): CommonServiceTestConfig() {
+
+    var member: MemberEntity? = null
 
     @BeforeEach
     fun setup() {
-        val member = memberRepository.save(MemberEntity(
+        member = memberRepository.save(MemberEntity(
                 nickname = "nickname",
                 provider = ProviderType.KAKAO,
                 providerUserId = "providerUserId",
@@ -33,7 +59,7 @@ class MemberServiceTest(
                 ageRange = "20",
                 status = MemberStatusType.ACTIVE
         ))
-        member.id.let { RequestUtils.setAttribute("memberId", it) }
+        member!!.id.let { RequestUtils.setAttribute("memberId", it) }
     }
 
     @Test
@@ -88,5 +114,78 @@ class MemberServiceTest(
         // then
         assertThat(availableResult.available).isEqualTo(true)
         assertThat(unavailableResult.available).isEqualTo(false)
+    }
+
+    @Test
+    fun 역_즐겨찾기_테스트() {
+        // given
+        val station1 = StationEntity(name = "시청역")
+        val station2 = StationEntity(name = "발산역")
+        val station3 = StationEntity(name = "강남역")
+        stationRepository.save(station1)
+        stationRepository.save(station2)
+        stationRepository.save(station3)
+
+        val command = BookmarkStationCommand(
+            stationNames = listOf(station1.name, station2.name, station3.name)
+        )
+
+        // when
+        val result = memberUseCase.bookmarkStation(command)
+
+        // then
+        assertThat(result.memberStationIds.size).isEqualTo(3)
+    }
+
+    @Test
+    fun 즐겨찾는_역이_3개_이상이면_실패() {
+        // given
+        val command = BookmarkStationCommand(
+            stationNames = listOf("시청역", "발산역", "강남역", "구로역")
+        )
+
+        // when + then
+        assertThatThrownBy {
+            memberUseCase.bookmarkStation(command)
+        }
+            .isExactlyInstanceOf(BusinessException::class.java)
+            .hasMessage(ResponseCode.EXCEED_MAXIMUM_STATION_COUNT.message)
+    }
+
+    @Test
+    fun 즐겨찾는_역_조회_테스트() {
+        // given
+        val stationList = listOf(StationEntity(name = "시청역"), StationEntity(name = "발산역"))
+        val subwayLines = listOf(
+            SubwayLineEntity(name = "1호선", regionType = RegionType.METROPOLITAN),
+            SubwayLineEntity(name = "5호선", regionType = RegionType.METROPOLITAN)
+        )
+
+        for (i in stationList.indices) {
+            val stationEntity = stationRepository.save(stationList[i])
+            val subwayLineEntity = subwayLineRepository.save(subwayLines[i])
+            memberStationRepository.save(
+                MemberStationEntity(
+                    member = member!!,
+                    station = stationEntity
+                )
+            )
+            subwayLineStationRepository.save(
+                SubwayLineStationEntity(
+                    station = stationEntity,
+                    subwayLine = subwayLineEntity
+                )
+            )
+        }
+
+        // when
+        val result = memberUseCase.getBookmarkStation()
+
+        // then
+        assertThat(result.stationInfoList.size).isEqualTo(2)
+        assertThat(result.stationInfoList[0].stationName).isEqualTo("시청역")
+        assertThat(result.stationInfoList[0].subwayLineInfoList[0].subwayLineName).isEqualTo("1호선")
+        assertThat(result.stationInfoList[1].stationName).isEqualTo("발산역")
+        assertThat(result.stationInfoList[1].subwayLineInfoList[0].subwayLineName).isEqualTo("5호선")
     }
 }


### PR DESCRIPTION
## 📚 개요
+ #188 

## ✏️ 작업 내용
+ 유저가 즐겨찾는 역 저장을 위한 MemberStation 테이블 생성
   + Member - Station 매핑 테이블 (N:N)
+ 즐겨찾기, 조회 기능 구현

## 💡 주의 사항
+ 로컬 테스트 시, data.sql 파일에서 sql 문 순서가 잘못되어 FK 참조 관련 에러가 발생해서 해결해놨습니다.
