### PR TITLE
:recycle: 열차 도착 데이터 정렬 방식 수정 (#200)

### DIFF
--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/train/adapter/in/dto/GetTrainRealTimesDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/train/adapter/in/dto/GetTrainRealTimesDto.kt
@@ -2,6 +2,7 @@ package backend.team.ahachul_backend.api.train.adapter.`in`.dto
 
 import backend.team.ahachul_backend.api.train.domain.model.TrainArrivalCode
 import backend.team.ahachul_backend.api.train.domain.model.UpDownType
+import backend.team.ahachul_backend.common.dto.RealtimeArrivalListDTO
 import com.fasterxml.jackson.annotation.JsonIgnore
 
 class GetTrainRealTimesDto {
@@ -26,8 +27,24 @@ class GetTrainRealTimesDto {
         val nextStationDirection: String,
         val destinationStationDirection: String,
         val trainNum: String,
-        val currentLocation: String,
+        val currentArrivalTime: Int = 0,
         val currentTrainArrivalCode: TrainArrivalCode,
     ) {
+
+        companion object {
+            fun from(it: RealtimeArrivalListDTO, stationOrder: Int): TrainRealTime {
+                val trainDirection = it.trainLineNm.split("-")
+                return TrainRealTime(
+                    subwayId = it.subwayId,
+                    stationOrder = stationOrder,
+                    upDownType = UpDownType.from(it.updnLine),
+                    nextStationDirection = trainDirection[1].trim(),
+                    destinationStationDirection = trainDirection[0].trim(),
+                    trainNum = it.btrainNo,
+                    currentArrivalTime = if (stationOrder == Int.MAX_VALUE) { 0 } else stationOrder,
+                    currentTrainArrivalCode = TrainArrivalCode.from(it.arvlCd)
+                )
+            }
+        }
     }
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/train/adapter/in/dto/GetTrainRealTimesDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/train/adapter/in/dto/GetTrainRealTimesDto.kt
@@ -27,7 +27,7 @@ class GetTrainRealTimesDto {
         val nextStationDirection: String,
         val destinationStationDirection: String,
         val trainNum: String,
-        val currentArrivalTime: Int = 0,
+        val currentArrivalTime: Int,
         val currentTrainArrivalCode: TrainArrivalCode,
     ) {
 

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/train/adapter/in/dto/GetTrainRealTimesDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/train/adapter/in/dto/GetTrainRealTimesDto.kt
@@ -32,7 +32,7 @@ class GetTrainRealTimesDto {
     ) {
 
         companion object {
-            fun from(it: RealtimeArrivalListDTO, stationOrder: Int): TrainRealTime {
+            fun of(it: RealtimeArrivalListDTO, stationOrder: Int): TrainRealTime {
                 val trainDirection = it.trainLineNm.split("-")
                 return TrainRealTime(
                     subwayId = it.subwayId,

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/train/application/service/TrainCacheUtils.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/train/application/service/TrainCacheUtils.kt
@@ -36,15 +36,6 @@ class TrainCacheUtils(
         }
     }
 
-    fun getSortedData(
-        trainRealTimes: List<GetTrainRealTimesDto.TrainRealTime>
-    ): List<GetTrainRealTimesDto.TrainRealTime> {
-        return trainRealTimes.sortedWith(compareBy(
-            { it.currentTrainArrivalCode.priority },
-            { it.stationOrder }
-        ))
-    }
-
     private fun createKey(subwayLineIdentity: Long, stationId: Long): String {
         return "${TRAIN_REAL_TIME_REDIS_PREFIX}${subwayLineIdentity}-$stationId"
     }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/train/application/service/TrainService.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/train/application/service/TrainService.kt
@@ -107,7 +107,7 @@ class TrainService(
             ?.groupBy { it.updnLine }
             ?.entries?.forEach { map ->
                 val lis = map.value.map { dto ->
-                    GetTrainRealTimesDto.TrainRealTime.from(dto, extractStationOrder(dto.arvlMsg2)) }
+                    GetTrainRealTimesDto.TrainRealTime.of(dto, extractStationOrder(dto.arvlMsg2)) }
                     .sortedWith( compareBy(
                             { it.currentTrainArrivalCode.priority },
                             { it.stationOrder }
@@ -175,7 +175,6 @@ class TrainService(
 
     companion object {
         const val DELIMITER = "|"
-        val pattern = "[\\d+]".toRegex()
-//        val pattern = "\\[(\\d+)]".toRegex()
+        val pattern = "\\d+".toRegex()
     }
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/train/application/service/TrainService.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/train/application/service/TrainService.kt
@@ -8,12 +8,10 @@ import backend.team.ahachul_backend.api.train.application.port.`in`.TrainUseCase
 import backend.team.ahachul_backend.api.train.application.port.`in`.command.GetCongestionCommand
 import backend.team.ahachul_backend.api.train.application.port.out.TrainReader
 import backend.team.ahachul_backend.api.train.domain.entity.TrainEntity
-import backend.team.ahachul_backend.api.train.domain.model.TrainArrivalCode
-import backend.team.ahachul_backend.api.train.domain.model.UpDownType
 import backend.team.ahachul_backend.common.client.SeoulTrainClient
 import backend.team.ahachul_backend.common.client.TrainCongestionClient
 import backend.team.ahachul_backend.common.client.dto.TrainCongestionDto
-import backend.team.ahachul_backend.common.dto.TrainRealTimeDto
+import backend.team.ahachul_backend.common.dto.RealtimeArrivalListDTO
 import backend.team.ahachul_backend.common.exception.AdapterException
 import backend.team.ahachul_backend.common.exception.BusinessException
 import backend.team.ahachul_backend.common.logging.Logger
@@ -74,58 +72,59 @@ class TrainService(
         trainRealTimeMap.forEach {
             trainCacheUtils.setCache(it.key.toLong(), stationId, it.value)
         }
+
         return trainRealTimeMap.getOrElse(subwayLineIdentity.toString()) { emptyList() }
     }
 
-    private fun requestTrainRealTimesAndSorting(stationName: String): Map<String, List<GetTrainRealTimesDto.TrainRealTime>> {
+    private fun requestTrainRealTimesAndSorting(
+        stationName: String
+    ): Map<String, List<GetTrainRealTimesDto.TrainRealTime>> {
         var startIndex = 1
         var endIndex = 5
         var totalSize = startIndex
-        val trainRealTimes = mutableListOf<GetTrainRealTimesDto.TrainRealTime>()
+        val totalTrainRealTimes = mutableListOf<RealtimeArrivalListDTO>()
 
         while (startIndex <= totalSize) {
             val trainRealTimesPublicData = seoulTrainClient.getTrainRealTimes(stationName, startIndex, endIndex)
             totalSize = trainRealTimesPublicData.errorMessage?.total ?: break
+            trainRealTimesPublicData.realtimeArrivalList?.let { totalTrainRealTimes.addAll(it) }
             startIndex = endIndex + 1
             endIndex = startIndex + 4
-            trainRealTimes.addAll(generateTrainRealTimeList(trainRealTimesPublicData))
         }
 
-        if (trainRealTimes.size == 0) {
+        if (totalTrainRealTimes.isEmpty()) {
             throw BusinessException(ResponseCode.NOT_EXIST_ARRIVAL_TRAIN)
         }
 
-        return trainRealTimes
-            .groupBy { it.subwayId!! }
-            .mapValues {
-                trainCacheUtils.getSortedData( it.value )
-            }
+        return totalTrainRealTimes
+            .groupBy { it.subwayId }
+            .mapValues { generateTrainRealTimeByUpDnType(it.value) }
     }
 
-    private fun generateTrainRealTimeList(trainRealTime: TrainRealTimeDto): List<GetTrainRealTimesDto.TrainRealTime> {
-        return trainRealTime.realtimeArrivalList
-            ?.map {
-                val trainDirection = it.trainLineNm.split("-")
-                GetTrainRealTimesDto.TrainRealTime(
-                    subwayId = it.subwayId,
-                    stationOrder = extractStationOrder(it.arvlMsg2),
-                    upDownType = UpDownType.from(it.updnLine),
-                    nextStationDirection = trainDirection[1].trim(),
-                    destinationStationDirection = trainDirection[0].trim(),
-                    trainNum = it.btrainNo,
-                    currentLocation = it.arvlMsg2.replace("\\d+초 후".toRegex(), "").trim(),
-                    currentTrainArrivalCode = TrainArrivalCode.from(it.arvlCd)
-                )
+    private fun generateTrainRealTimeByUpDnType(trainRealTime: List<RealtimeArrivalListDTO>?): List<GetTrainRealTimesDto.TrainRealTime> {
+        val total = mutableListOf<GetTrainRealTimesDto.TrainRealTime>()
+        trainRealTime
+            ?.groupBy { it.updnLine }
+            ?.entries?.forEach { map ->
+                val lis = map.value.map { dto ->
+                    GetTrainRealTimesDto.TrainRealTime.from(dto, extractStationOrder(dto.arvlMsg2)) }
+                    .sortedWith( compareBy(
+                            { it.currentTrainArrivalCode.priority },
+                            { it.stationOrder }
+                    )).subList(0, 2)
+                total.addAll(lis)
             }
-            ?: emptyList()
+        return total
     }
 
+    /**
+     * 도착 우선순위 추출
+     */
     private fun extractStationOrder(destinationMessage: String): Int {
         return if (destinationMessage.startsWith("[")) {
-            pattern.find(destinationMessage)?.groupValues
-                ?.getOrNull(1)
-                ?.toInt()
-                ?: Int.MAX_VALUE
+            pattern.find(destinationMessage)!!.value.toInt().times(2)
+        } else if (destinationMessage.contains("분")) {
+            pattern.find(destinationMessage)!!.value.toInt()
         } else {
             Int.MAX_VALUE
         }
@@ -176,6 +175,7 @@ class TrainService(
 
     companion object {
         const val DELIMITER = "|"
-        val pattern = "\\[(\\d+)]".toRegex()
+        val pattern = "[\\d+]".toRegex()
+//        val pattern = "\\[(\\d+)]".toRegex()
     }
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/schedule/config/ScheduleConfig.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/schedule/config/ScheduleConfig.kt
@@ -52,7 +52,7 @@ class ScheduleConfig(
             .withIdentity(TriggerKey("UPDATE_LOST_DATA_TRIGGER ", "LOST"))
             .startNow()
             .withSchedule(
-                CronScheduleBuilder.cronSchedule("30 24 * ? * *")
+                CronScheduleBuilder.cronSchedule("0 0 16 * * * *")   // 매일 밤 새벽 한시(UTC)
                     .withMisfireHandlingInstructionFireAndProceed()
             )
             .build()

--- a/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/AhachulBackendApplicationTests.kt
+++ b/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/AhachulBackendApplicationTests.kt
@@ -8,5 +8,4 @@ class AhachulBackendApplicationTests {
     @Test
     fun contextLoads() {
     }
-
 }

--- a/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/train/adapter/in/TrainControllerDocsTest.kt
+++ b/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/train/adapter/in/TrainControllerDocsTest.kt
@@ -140,7 +140,7 @@ class TrainControllerDocsTest : CommonDocsTestConfig() {
                 nextStationDirection = "신대방방면",
                 destinationStationDirection = "성수행",
                 trainNum = "2234",
-                currentLocation = "전역 도착",
+                currentArrivalTime = 0,
                 currentTrainArrivalCode = TrainArrivalCode.BEFORE_STATION_ARRIVE
             ),
             GetTrainRealTimesDto.TrainRealTime(
@@ -150,7 +150,7 @@ class TrainControllerDocsTest : CommonDocsTestConfig() {
                 nextStationDirection = "봉천방면",
                 destinationStationDirection = "성수행",
                 trainNum = "2236",
-                currentLocation = "6분",
+                currentArrivalTime = 6,
                 currentTrainArrivalCode = TrainArrivalCode.RUNNING
             )
         )
@@ -188,7 +188,7 @@ class TrainControllerDocsTest : CommonDocsTestConfig() {
                         fieldWithPath("result.trainRealTimes[].nextStationDirection").type(JsonFieldType.STRING).description("다음 정류장 방향"),
                         fieldWithPath("result.trainRealTimes[].destinationStationDirection").type(JsonFieldType.STRING).description("목적지 방향"),
                         fieldWithPath("result.trainRealTimes[].trainNum").type(JsonFieldType.STRING).description("해당 열차 ID"),
-                        fieldWithPath("result.trainRealTimes[].currentLocation").type(JsonFieldType.STRING).description("해당 열차 현재 위치"),
+                        fieldWithPath("result.trainRealTimes[].currentArrivalTime").type(JsonFieldType.NUMBER).description("열차 도착 시간(몇분 후)"),
                         fieldWithPath("result.trainRealTimes[].currentTrainArrivalCode").type(JsonFieldType.STRING).description("해당 열차 현재 위치 코드").attributes(getFormatAttribute("ENTER(진입), ARRIVE(도착), DEPARTURE(출발), BEFORE_STATION_DEPARTURE(전역출발), BEFORE_STATION_ENTER(전역진입), BEFORE_STATION_ARRIVE(전역도착), RUNNING(운행중)")),
                     )
                 )

--- a/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/train/application/service/TrainCacheUtilsTest.kt
+++ b/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/train/application/service/TrainCacheUtilsTest.kt
@@ -12,23 +12,23 @@ class TrainCacheUtilsTest(
     @Autowired val trainCacheUtils: TrainCacheUtils
 ): CommonServiceTestConfig() {
 
-    @Test
-    fun 가장_역에_근접한_열차의_순으로_정렬한다() {
-        // given
-        val realTimeTrainData = listOf(
-            createTrainRealTime(1, "2236", "6분", TrainArrivalCode.RUNNING),
-            createTrainRealTime(2, "2238", "전역 도착", TrainArrivalCode.BEFORE_STATION_ARRIVE),
-            createTrainRealTime(1, "2234", "전역 도착", TrainArrivalCode.BEFORE_STATION_ARRIVE)
-        )
-
-        // when
-        val result = trainCacheUtils.getSortedData(realTimeTrainData)
-
-        // then
-        assertThat(result[0].trainNum).isEqualTo(realTimeTrainData[2].trainNum)
-        assertThat(result[1].trainNum).isEqualTo(realTimeTrainData[1].trainNum)
-        assertThat(result[2].trainNum).isEqualTo(realTimeTrainData[0].trainNum)
-    }
+//    @Test
+//    fun 가장_역에_근접한_열차의_순으로_정렬한다() {
+//        // given
+//        val realTimeTrainData = listOf(
+//            createTrainRealTime(1, "2236", "6분", TrainArrivalCode.RUNNING),
+//            createTrainRealTime(2, "2238", "전역 도착", TrainArrivalCode.BEFORE_STATION_ARRIVE),
+//            createTrainRealTime(1, "2234", "전역 도착", TrainArrivalCode.BEFORE_STATION_ARRIVE)
+//        )
+//
+//        // when
+//        val result = trainCacheUtils.getSortedData(realTimeTrainData)
+//
+//        // then
+//        assertThat(result[0].trainNum).isEqualTo(realTimeTrainData[2].trainNum)
+//        assertThat(result[1].trainNum).isEqualTo(realTimeTrainData[1].trainNum)
+//        assertThat(result[2].trainNum).isEqualTo(realTimeTrainData[0].trainNum)
+//    }
 
     private fun createTrainRealTime(
         stationOrder: Int, trainNum: String , currentLocation: String, currentTrainArrivalCode: TrainArrivalCode)
@@ -40,7 +40,7 @@ class TrainCacheUtilsTest(
             nextStationDirection = "신대방방면",
             destinationStationDirection = "성수행",
             trainNum = trainNum,
-            currentLocation = currentLocation,
+//            currentLocation = currentLocation,
             currentTrainArrivalCode = currentTrainArrivalCode
         )
     }


### PR DESCRIPTION
## 📚 개요
+ #200 

## ✏️ 작업 내용
+ 변경 이전  : 상/하행 구분 없이 모든 열차 데이터 반환
+ 변경 이후
  + `Running` 상태( `[X번째] 전역` 과 `X분 후 도착` ) 데이터는 열차가 몇 분후에 도착하는지 메타 데이터 반환하고, 전역 도착이나 도착은 `0` 반환하도록 했습니다.( `currentTrainArrivalCode` 로 프론트에서 구별할 수 있을것 같아서요)
  + 상/하행 별로 가장 근접한 열차 데이터만 2개씩 가져도오록 변경했습니다.
  + 정렬 메서드 `cacheUtils` 두는건 좀 안어울리는 것 같아서 뺐어요.
 
```json
  "trainRealTimes": [
            {
                "upDownType": "UP",
                "nextStationDirection": "종각방면",
                "destinationStationDirection": "광운대행",
                "trainNum": "0640",
                "currentArrivalTime": 0,
                "currentTrainArrivalCode": "BEFORE_STATION_DEPARTURE"
            },
            {
                "upDownType": "UP",
                "nextStationDirection": "종각방면",
                "destinationStationDirection": "동두천행",
                "trainNum": "1614",
                "currentArrivalTime": 2,
                "currentTrainArrivalCode": "RUNNING"
            },
            {
                "upDownType": "DOWN",
                "nextStationDirection": "서울방면",
                "destinationStationDirection": "구로행",
                "trainNum": "0807",
                "currentArrivalTime": 0,
                "currentTrainArrivalCode": "ARRIVE"
            },
            {
                "upDownType": "DOWN",
                "nextStationDirection": "서울방면",
                "destinationStationDirection": "병점행",
                "trainNum": "0457",
                "currentArrivalTime": 0,
                "currentTrainArrivalCode": "BEFORE_STATION_ARRIVE"
            }
        ]
  ```
