### PR TITLE
:sparkles: 민원 조회 API 구현 및 민원 인증 필수 제거 (#209)

### DIFF
--- a/ahachul_backend/src/docs/asciidoc/complaint/complaints.adoc
+++ b/ahachul_backend/src/docs/asciidoc/complaint/complaints.adoc
@@ -11,9 +11,20 @@ include::{snippets}/send-complaint-message/request-fields.adoc[]
 .Response
 include::{snippets}/send-complaint-message/http-response.adoc[]
 
+==== 민원 메시지 조회
+
+.Request
+include::{snippets}/search-complaint-messages/http-request.adoc[]
+.Query Parameters
+include::{snippets}/search-complaint-messages/query-parameters.adoc[]
+.Response
+include::{snippets}/search-complaint-messages/http-response.adoc[]
+.Response Fields
+include::{snippets}/search-complaint-messages/response-fields.adoc[]
+
 ==== Model
 
-===== ComplaintMessageType
+===== ComplaintMessageStatusType
 
 CREATED
 IN_PROGRESS

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/complaint/adapter/in/ComplaintController.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/complaint/adapter/in/ComplaintController.kt
@@ -1,9 +1,12 @@
 package backend.team.ahachul_backend.api.complaint.adapter.`in`
 
+import backend.team.ahachul_backend.api.complaint.adapter.`in`.dto.SearchComplaintMessagesDto
 import backend.team.ahachul_backend.api.complaint.adapter.`in`.dto.SendComplaintMessageDto
 import backend.team.ahachul_backend.api.complaint.application.port.`in`.ComplaintUseCase
 import backend.team.ahachul_backend.common.annotation.Authentication
 import backend.team.ahachul_backend.common.response.CommonResponse
+import org.springframework.data.domain.Pageable
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
@@ -12,6 +15,10 @@ import org.springframework.web.bind.annotation.RestController
 class ComplaintController(
     private val complaintUseCase: ComplaintUseCase,
 ) {
+    @GetMapping("/v1/complaints/messages")
+    fun searchComplaintMessages(pageable: Pageable): CommonResponse<SearchComplaintMessagesDto.Response> {
+        return CommonResponse.success(complaintUseCase.searchComplaintMessages(pageable))
+    }
 
     @Authentication
     @PostMapping("/v1/complaints/messages")

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/complaint/adapter/in/ComplaintController.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/complaint/adapter/in/ComplaintController.kt
@@ -20,7 +20,7 @@ class ComplaintController(
         return CommonResponse.success(complaintUseCase.searchComplaintMessages(pageable))
     }
 
-    @Authentication
+    @Authentication(required = false)
     @PostMapping("/v1/complaints/messages")
     fun sendComplaintMessage(@RequestBody request: SendComplaintMessageDto.Request): CommonResponse<Unit> {
         complaintUseCase.sendComplaintMessage(request.toCommand())

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/complaint/adapter/in/dto/SearchComplaintMessagesDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/complaint/adapter/in/dto/SearchComplaintMessagesDto.kt
@@ -1,0 +1,39 @@
+package backend.team.ahachul_backend.api.complaint.adapter.`in`.dto
+
+import backend.team.ahachul_backend.api.complaint.domain.model.ComplaintMessageStatusType
+import backend.team.ahachul_backend.api.complaint.domain.model.ComplaintType
+import backend.team.ahachul_backend.api.complaint.domain.model.ShortContentType
+import java.time.LocalDateTime
+
+class SearchComplaintMessagesDto {
+
+    data class Response(
+        val hasNext: Boolean,
+        val nextPageNum: Int?,
+        val complaintMessages: List<ComplaintMessage>
+    ) {
+        companion object {
+            fun of(hasNext: Boolean, complaintMessages: List<ComplaintMessage>, currentPageNum: Int): Response {
+                return Response(
+                    hasNext = hasNext,
+                    nextPageNum = if (hasNext) currentPageNum + 1 else null,
+                    complaintMessages = complaintMessages
+                )
+            }
+        }
+    }
+
+    data class ComplaintMessage(
+        val content: String,
+        val complainType: ComplaintType,
+        val shortContentType: ShortContentType? = null,
+        val complaintMessageStatusType: ComplaintMessageStatusType,
+        val phoneNumber: String,
+        val trainNo: String,
+        val location: Int,
+        val subwayLineId: Long,
+        val createdAt: LocalDateTime,
+        val createdBy: String,
+        val writer: String,
+    )
+}

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/complaint/adapter/in/dto/SendComplaintMessageCommand.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/complaint/adapter/in/dto/SendComplaintMessageCommand.kt
@@ -16,7 +16,7 @@ class SendComplaintMessageCommand(
     val subwayLineId: Long,
 ) {
 
-    fun toEntity(member: MemberEntity, subwayLine: SubwayLineEntity): ComplaintMessageHistoryEntity {
+    fun toEntity(member: MemberEntity?, subwayLine: SubwayLineEntity): ComplaintMessageHistoryEntity {
         return ComplaintMessageHistoryEntity(
             sentContent = content,
             complaintType = complainType,

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/complaint/adapter/out/ComplaintPersistence.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/complaint/adapter/out/ComplaintPersistence.kt
@@ -1,15 +1,22 @@
 package backend.team.ahachul_backend.api.complaint.adapter.out
 
+import backend.team.ahachul_backend.api.complaint.application.port.out.ComplaintReader
 import backend.team.ahachul_backend.api.complaint.application.port.out.ComplaintWriter
 import backend.team.ahachul_backend.api.complaint.domain.entity.ComplaintMessageHistoryEntity
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Component
 
 @Component
 class ComplaintPersistence(
     private val repository: ComplaintMessageHistoryRepository,
-): ComplaintWriter {
+): ComplaintWriter, ComplaintReader {
 
     override fun save(entity: ComplaintMessageHistoryEntity): ComplaintMessageHistoryEntity {
         return repository.save(entity)
+    }
+
+    override fun findAll(pageable: Pageable): Page<ComplaintMessageHistoryEntity> {
+        return repository.findAll(pageable)
     }
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/complaint/application/port/in/ComplaintUseCase.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/complaint/application/port/in/ComplaintUseCase.kt
@@ -1,8 +1,12 @@
 package backend.team.ahachul_backend.api.complaint.application.port.`in`
 
+import backend.team.ahachul_backend.api.complaint.adapter.`in`.dto.SearchComplaintMessagesDto
 import backend.team.ahachul_backend.api.complaint.adapter.`in`.dto.SendComplaintMessageCommand
+import org.springframework.data.domain.Pageable
 
 interface ComplaintUseCase {
+
+    fun searchComplaintMessages(pageable: Pageable): SearchComplaintMessagesDto.Response
 
     fun sendComplaintMessage(command: SendComplaintMessageCommand)
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/complaint/application/port/out/ComplaintReader.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/complaint/application/port/out/ComplaintReader.kt
@@ -1,0 +1,10 @@
+package backend.team.ahachul_backend.api.complaint.application.port.out
+
+import backend.team.ahachul_backend.api.complaint.domain.entity.ComplaintMessageHistoryEntity
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+
+interface ComplaintReader {
+
+    fun findAll(pageable: Pageable): Page<ComplaintMessageHistoryEntity>
+}

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/complaint/application/service/ComplaintService.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/complaint/application/service/ComplaintService.kt
@@ -34,7 +34,7 @@ class ComplaintService(
                 subwayLineId = it.subwayLine.id,
                 createdAt = it.createdAt,
                 createdBy = it.createdBy,
-                writer = it.member.nickname!!
+                writer = it.member!!.nickname!!
             ) }
 
         return SearchComplaintMessagesDto.Response.of(
@@ -46,10 +46,12 @@ class ComplaintService(
 
     @Transactional
     override fun sendComplaintMessage(command: SendComplaintMessageCommand) {
-        val memberId = RequestUtils.getAttribute("memberId")!!
+        val memberId = RequestUtils.getAttribute("memberId")
+        val member = memberId?.let { memberReader.getMember(it.toLong()) }
+
         complaintWriter.save(
             command.toEntity(
-                memberReader.getMember(memberId.toLong()),
+                member,
                 subwayLineReader.getById(command.subwayLineId))
         )
     }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/complaint/application/service/ComplaintService.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/complaint/application/service/ComplaintService.kt
@@ -1,11 +1,14 @@
 package backend.team.ahachul_backend.api.complaint.application.service
 
+import backend.team.ahachul_backend.api.complaint.adapter.`in`.dto.SearchComplaintMessagesDto
 import backend.team.ahachul_backend.api.complaint.adapter.`in`.dto.SendComplaintMessageCommand
 import backend.team.ahachul_backend.api.complaint.application.port.`in`.ComplaintUseCase
+import backend.team.ahachul_backend.api.complaint.application.port.out.ComplaintReader
 import backend.team.ahachul_backend.api.complaint.application.port.out.ComplaintWriter
 import backend.team.ahachul_backend.api.member.application.port.out.MemberReader
 import backend.team.ahachul_backend.common.persistence.SubwayLineReader
 import backend.team.ahachul_backend.common.utils.RequestUtils
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -13,9 +16,33 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional(readOnly = true)
 class ComplaintService(
     private val complaintWriter: ComplaintWriter,
+    private val complaintReader: ComplaintReader,
     private val memberReader: MemberReader,
     private val subwayLineReader: SubwayLineReader,
 ): ComplaintUseCase {
+
+    override fun searchComplaintMessages(pageable: Pageable): SearchComplaintMessagesDto.Response {
+        val complaintMessages = complaintReader.findAll(pageable)
+            .map { SearchComplaintMessagesDto.ComplaintMessage(
+                content = it.sentContent,
+                complainType = it.complaintType,
+                shortContentType = it.shortContentType,
+                complaintMessageStatusType = it.complaintMessageStatusType,
+                phoneNumber = it.sentPhoneNumber,
+                trainNo = it.sentTrainNo,
+                location = it.location,
+                subwayLineId = it.subwayLine.id,
+                createdAt = it.createdAt,
+                createdBy = it.createdBy,
+                writer = it.member.nickname!!
+            ) }
+
+        return SearchComplaintMessagesDto.Response.of(
+            hasNext = complaintMessages.size > complaintMessages.pageable.pageSize,
+            currentPageNum = pageable.pageNumber,
+            complaintMessages = complaintMessages.content
+        )
+    }
 
     @Transactional
     override fun sendComplaintMessage(command: SendComplaintMessageCommand) {

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/complaint/domain/entity/ComplaintMessageHistoryEntity.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/complaint/domain/entity/ComplaintMessageHistoryEntity.kt
@@ -34,7 +34,7 @@ class ComplaintMessageHistoryEntity(
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sent_member_id")
-    val member: MemberEntity,
+    val member: MemberEntity? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sent_subway_line_id")

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/complaint/domain/entity/ComplaintMessageHistoryEntity.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/complaint/domain/entity/ComplaintMessageHistoryEntity.kt
@@ -1,6 +1,6 @@
 package backend.team.ahachul_backend.api.complaint.domain.entity
 
-import backend.team.ahachul_backend.api.complaint.domain.model.ComplaintMessageType
+import backend.team.ahachul_backend.api.complaint.domain.model.ComplaintMessageStatusType
 import backend.team.ahachul_backend.api.complaint.domain.model.ComplaintType
 import backend.team.ahachul_backend.api.complaint.domain.model.ShortContentType
 import backend.team.ahachul_backend.api.member.domain.entity.MemberEntity
@@ -30,7 +30,7 @@ class ComplaintMessageHistoryEntity(
     val location: Int,
 
     @Enumerated(EnumType.STRING)
-    val complaintMessageType: ComplaintMessageType = ComplaintMessageType.CREATED,
+    val complaintMessageStatusType: ComplaintMessageStatusType = ComplaintMessageStatusType.CREATED,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sent_member_id")

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/complaint/domain/model/ComplaintMessageStatusType.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/complaint/domain/model/ComplaintMessageStatusType.kt
@@ -1,5 +1,5 @@
 package backend.team.ahachul_backend.api.complaint.domain.model
 
-enum class ComplaintMessageType {
+enum class ComplaintMessageStatusType {
     CREATED, IN_PROGRESS, COMPLETED;
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/interceptor/AuthenticationInterceptor.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/interceptor/AuthenticationInterceptor.kt
@@ -12,7 +12,6 @@ import io.jsonwebtoken.UnsupportedJwtException
 import io.jsonwebtoken.security.SignatureException
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
-import org.apache.http.protocol.ResponseServer
 import org.springframework.stereotype.Component
 import org.springframework.web.method.HandlerMethod
 import org.springframework.web.servlet.HandlerInterceptor

--- a/ahachul_backend/src/main/resources/db/migration/V202404130045__update_complaint_message.sql
+++ b/ahachul_backend/src/main/resources/db/migration/V202404130045__update_complaint_message.sql
@@ -5,7 +5,7 @@ ALTER TABLE tb_complaint_message_history
     ADD COLUMN short_content_type VARCHAR(20);
 
 ALTER TABLE tb_complaint_message_history
-    ADD COLUMN complaint_message_type VARCHAR(20) NOT NULL;
+    ADD COLUMN complaint_message_status_type VARCHAR(20) NOT NULL;
 
 ALTER TABLE tb_complaint_message_history
     ADD COLUMN location INT NOT NULL;

--- a/ahachul_backend/src/main/resources/db/migration/V202404130045__update_complaint_message.sql
+++ b/ahachul_backend/src/main/resources/db/migration/V202404130045__update_complaint_message.sql
@@ -9,3 +9,6 @@ ALTER TABLE tb_complaint_message_history
 
 ALTER TABLE tb_complaint_message_history
     ADD COLUMN location INT NOT NULL;
+
+ALTER TABLE tb_complaint_message_history
+    MODIFY sent_member_id BIGINT NULL;

--- a/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/complaint/adapter/in/ComplaintControllerDocsTest.kt
+++ b/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/complaint/adapter/in/ComplaintControllerDocsTest.kt
@@ -1,11 +1,14 @@
 package backend.team.ahachul_backend.api.complaint.adapter.`in`
 
+import backend.team.ahachul_backend.api.complaint.adapter.`in`.dto.SearchComplaintMessagesDto
 import backend.team.ahachul_backend.api.complaint.adapter.`in`.dto.SendComplaintMessageDto
 import backend.team.ahachul_backend.api.complaint.application.port.`in`.ComplaintUseCase
+import backend.team.ahachul_backend.api.complaint.domain.model.ComplaintMessageStatusType
 import backend.team.ahachul_backend.api.complaint.domain.model.ComplaintType
 import backend.team.ahachul_backend.api.complaint.domain.model.ShortContentType
 import backend.team.ahachul_backend.config.controller.CommonDocsTestConfig
 import org.junit.jupiter.api.Test
+import org.mockito.BDDMockito.given
 import org.mockito.BDDMockito.willDoNothing
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.boot.test.mock.mockito.MockBean
@@ -13,14 +16,84 @@ import org.springframework.http.MediaType
 import org.springframework.restdocs.headers.HeaderDocumentation
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get
+import org.springframework.restdocs.payload.JsonFieldType
 import org.springframework.restdocs.payload.PayloadDocumentation
+import org.springframework.restdocs.request.RequestDocumentation
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import java.time.LocalDateTime
 
 @WebMvcTest(ComplaintController::class)
 class ComplaintControllerDocsTest: CommonDocsTestConfig() {
 
     @MockBean
     lateinit var complaintUseCase: ComplaintUseCase
+
+    @Test
+    fun searchComplaintMessagesTest() {
+        // given
+        val response = SearchComplaintMessagesDto.Response(
+            true,
+            1,
+            listOf(
+                SearchComplaintMessagesDto.ComplaintMessage(
+                    content = "내용",
+                    complainType = ComplaintType.TEMPERATURE_CONTROL,
+                    shortContentType = ShortContentType.TOO_COLD,
+                    complaintMessageStatusType = ComplaintMessageStatusType.CREATED,
+                    subwayLineId = 1L,
+                    trainNo = "4323",
+                    location = 1,
+                    phoneNumber = "010-1234-1234",
+                    createdAt = LocalDateTime.now(),
+                    createdBy = "작성자 ID",
+                    writer = "작성자 닉네임",
+                )
+            )
+        )
+
+        given(complaintUseCase.searchComplaintMessages((any()))).willReturn(response)
+
+        // when
+        val result = mockMvc.perform(
+            get("/v1/complaints/messages")
+                .param("page", "1")
+                .param("size", "10")
+                .param("sort", "createdAt,desc")
+                .accept(MediaType.APPLICATION_JSON)
+        )
+
+        // then
+        result.andExpect(MockMvcResultMatchers.status().isOk)
+            .andDo(
+                MockMvcRestDocumentation.document(
+                    "search-complaint-messages",
+                    getDocsRequest(),
+                    getDocsResponse(),
+                    RequestDocumentation.queryParameters(
+                        RequestDocumentation.parameterWithName("page").description("현재 페이지"),
+                        RequestDocumentation.parameterWithName("size").description("페이지 노출 데이터 수. index 0부터 시작"),
+                        RequestDocumentation.parameterWithName("sort").description("정렬 조건").attributes(getFormatAttribute("(likes|createdAt|views),(asc|desc)")),
+                    ),
+                    PayloadDocumentation.responseFields(
+                        *commonResponseFields(),
+                        PayloadDocumentation.fieldWithPath("result.hasNext").type(JsonFieldType.BOOLEAN).description("다음 페이지 존재 여부"),
+                        PayloadDocumentation.fieldWithPath("result.nextPageNum").type(JsonFieldType.NUMBER).description("다음 페이지 인덱스"),
+                        PayloadDocumentation.fieldWithPath("result.complaintMessages[].content").type(JsonFieldType.STRING).description("민원 내용"),
+                        PayloadDocumentation.fieldWithPath("result.complaintMessages[].complainType").type(JsonFieldType.STRING).description("민원 타입(ComplainType)"),
+                        PayloadDocumentation.fieldWithPath("result.complaintMessages[].shortContentType").type(JsonFieldType.STRING).description("민원 짧은 내용 타입(ShortContentType)"),
+                        PayloadDocumentation.fieldWithPath("result.complaintMessages[].complaintMessageStatusType").type(JsonFieldType.STRING).description("민원 상태(ComplaintMessageStatusType)"),
+                        PayloadDocumentation.fieldWithPath("result.complaintMessages[].subwayLineId").type(JsonFieldType.NUMBER).description("지하철 노선 ID"),
+                        PayloadDocumentation.fieldWithPath("result.complaintMessages[].trainNo").type(JsonFieldType.STRING).description("열차 번호"),
+                        PayloadDocumentation.fieldWithPath("result.complaintMessages[].location").type(JsonFieldType.NUMBER).description("열차 칸"),
+                        PayloadDocumentation.fieldWithPath("result.complaintMessages[].phoneNumber").type(JsonFieldType.STRING).description("전화번호"),
+                        PayloadDocumentation.fieldWithPath("result.complaintMessages[].createdAt").type("LocalDateTime").description("작성일자"),
+                        PayloadDocumentation.fieldWithPath("result.complaintMessages[].createdBy").type(JsonFieldType.STRING).description("작성자 ID"),
+                        PayloadDocumentation.fieldWithPath("result.complaintMessages[].writer").type(JsonFieldType.STRING).description("작성자 닉네임"),
+                    )
+                )
+            )
+    }
 
     @Test
     fun sendComplaintMessageTest() {


### PR DESCRIPTION
## 📚 개요
- close #209 

## ✏️ 작업 내용
- 민원 조회 API 구현 및 민원 인증 필수 제거
