### PR TITLE
:recycle: 커서 기반 페이징 방식 수정 (#222)

### DIFF
--- a/ahachul_backend/build.gradle.kts
+++ b/ahachul_backend/build.gradle.kts
@@ -91,7 +91,6 @@ dependencies {
     implementation("io.github.resilience4j:resilience4j-spring-boot3:2.0.2")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-aop")
-    implementation(kotlin("stdlib-jdk8"))
 }
 
 tasks.withType<KotlinCompile> {
@@ -146,12 +145,4 @@ tasks.register<Copy>("copyTestSecret") {
 tasks.named("compileJava") {
     dependsOn("copySecret")
     dependsOn("copyTestSecret")
-}
-val compileKotlin: KotlinCompile by tasks
-compileKotlin.kotlinOptions {
-    jvmTarget = "17"
-}
-val compileTestKotlin: KotlinCompile by tasks
-compileTestKotlin.kotlinOptions {
-    jvmTarget = "17"
 }

--- a/ahachul_backend/build.gradle.kts
+++ b/ahachul_backend/build.gradle.kts
@@ -91,6 +91,7 @@ dependencies {
     implementation("io.github.resilience4j:resilience4j-spring-boot3:2.0.2")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-aop")
+    implementation(kotlin("stdlib-jdk8"))
 }
 
 tasks.withType<KotlinCompile> {
@@ -145,4 +146,12 @@ tasks.register<Copy>("copyTestSecret") {
 tasks.named("compileJava") {
     dependsOn("copySecret")
     dependsOn("copyTestSecret")
+}
+val compileKotlin: KotlinCompile by tasks
+compileKotlin.kotlinOptions {
+    jvmTarget = "17"
+}
+val compileTestKotlin: KotlinCompile by tasks
+compileTestKotlin.kotlinOptions {
+    jvmTarget = "17"
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/lost/adapter/web/in/LostPostController.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/lost/adapter/web/in/LostPostController.kt
@@ -3,8 +3,8 @@ package backend.team.ahachul_backend.api.lost.adapter.web.`in`
 import backend.team.ahachul_backend.api.lost.adapter.web.`in`.dto.*
 import backend.team.ahachul_backend.api.lost.application.port.`in`.LostPostUseCase
 import backend.team.ahachul_backend.common.annotation.Authentication
+import backend.team.ahachul_backend.common.dto.PageInfoDto
 import backend.team.ahachul_backend.common.response.CommonResponse
-import org.springframework.data.domain.Pageable
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 
@@ -21,10 +21,11 @@ class LostPostController(
 
     @GetMapping("/v1/lost-posts")
     fun searchLostPosts(
-        pageable: Pageable,
+        @RequestParam(required = false) pageToken: String?,
+        @RequestParam pageSize: Int,
         request: SearchLostPostsDto.Request
-    ): CommonResponse<SearchLostPostsDto.Response> {
-        return CommonResponse.success(lostPostService.searchLostPosts(request.toCommand(pageable)))
+    ): CommonResponse<PageInfoDto<SearchLostPostsDto.Response>> {
+        return CommonResponse.success(lostPostService.searchLostPosts(request.toCommand(pageToken, pageSize)))
     }
 
     @Authentication

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/lost/adapter/web/in/dto/SearchLostPostsDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/lost/adapter/web/in/dto/SearchLostPostsDto.kt
@@ -11,14 +11,12 @@ class SearchLostPostsDto {
     data class Request(
         val lostType: LostType,
         val subwayLineId: Long?,
-        val origin: LostOrigin?,
         val keyword: String?
     ) {
         fun toCommand(pageable: Pageable): SearchLostPostCommand {
             return SearchLostPostCommand(
                 lostType = lostType,
                 subwayLineId = subwayLineId,
-                lostOrigin = origin,
                 keyword = keyword,
                 pageable = pageable
             )

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/lost/adapter/web/in/dto/SearchLostPostsDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/lost/adapter/web/in/dto/SearchLostPostsDto.kt
@@ -4,41 +4,40 @@ import backend.team.ahachul_backend.api.lost.application.service.command.`in`.Se
 import backend.team.ahachul_backend.api.lost.domain.model.LostOrigin
 import backend.team.ahachul_backend.api.lost.domain.model.LostStatus
 import backend.team.ahachul_backend.api.lost.domain.model.LostType
-import org.springframework.data.domain.Pageable
 
 class SearchLostPostsDto {
 
     data class Request(
         val lostType: LostType,
+        val lostOrigin: LostOrigin,
         val subwayLineId: Long?,
-        val keyword: String?
+        val category: String?,
+        val keyword: String?,
     ) {
-        fun toCommand(pageable: Pageable): SearchLostPostCommand {
+        fun toCommand(pageToken: String?, pageSize: Int): SearchLostPostCommand {
             return SearchLostPostCommand(
                 lostType = lostType,
+                lostOrigin = lostOrigin,
                 subwayLineId = subwayLineId,
                 keyword = keyword,
-                pageable = pageable
+                category = category,
+                pageToken = pageToken,
+                pageSize = pageSize
             )
         }
     }
 
     data class Response(
-        val hasNext: Boolean,
-        val posts: List<SearchLost>
-    )
-
-    data class SearchLost(
         val id: Long,
         val title: String,
         val content: String,
         val writer: String?,
         val createdBy: String,
-        val date: String,
-        val subwayLine: Long?,
-        val chats: Int = 0,
+        val createdAt: String,
+        val subwayLineId: Long?,
+        val chatCnt: Int = 0,
         val status: LostStatus,
-        val imageUrl: String?,
+        val image: String?,
         val categoryName: String?
     )
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/lost/adapter/web/out/CustomLostPostRepository.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/lost/adapter/web/out/CustomLostPostRepository.kt
@@ -64,7 +64,6 @@ class CustomLostPostRepository(
         val pageable = command.pageable
         val response = queryFactory.selectFrom(lostPostEntity)
             .where(
-                lostOriginEq(command.lostOrigin),
                 subwayLineEq(command.subwayLine),
                 lostTypeEq(command.lostType),
                 titleAndContentLike(command.keyword),
@@ -117,9 +116,6 @@ class CustomLostPostRepository(
             .limit(command.size)
             .fetch()
     }
-
-    private fun lostOriginEq(lostOrigin: LostOrigin?) =
-        lostOrigin?.let { lostPostEntity.origin.eq(lostOrigin) }
 
     private fun subwayLineEq(subwayLine: SubwayLineEntity?) =
         subwayLine?.let { lostPostEntity.subwayLine.eq(subwayLine) }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/lost/adapter/web/out/LostPostPersistence.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/lost/adapter/web/out/LostPostPersistence.kt
@@ -29,7 +29,7 @@ class LostPostPersistence(
             .orElseThrow { throw AdapterException(ResponseCode.INVALID_DOMAIN) }
     }
 
-    override fun getLostPosts(command: GetSliceLostPostsCommand): Slice<LostPostEntity> {
+    override fun getLostPosts(command: GetSliceLostPostsCommand): List<LostPostEntity> {
         return customLostPostRepository.searchLostPosts(command)
     }
 

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/lost/application/port/in/LostPostUseCase.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/lost/application/port/in/LostPostUseCase.kt
@@ -4,12 +4,13 @@ import backend.team.ahachul_backend.api.lost.adapter.web.`in`.dto.*
 import backend.team.ahachul_backend.api.lost.application.service.command.`in`.CreateLostPostCommand
 import backend.team.ahachul_backend.api.lost.application.service.command.`in`.SearchLostPostCommand
 import backend.team.ahachul_backend.api.lost.application.service.command.`in`.UpdateLostPostCommand
+import backend.team.ahachul_backend.common.dto.PageInfoDto
 
 interface LostPostUseCase {
 
     fun getLostPost(id: Long): GetLostPostDto.Response
 
-    fun searchLostPosts(command: SearchLostPostCommand): SearchLostPostsDto.Response
+    fun searchLostPosts(command: SearchLostPostCommand): PageInfoDto<SearchLostPostsDto.Response>
 
     fun createLostPost(command: CreateLostPostCommand): CreateLostPostDto.Response
 

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/lost/application/port/out/LostPostReader.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/lost/application/port/out/LostPostReader.kt
@@ -9,7 +9,7 @@ interface LostPostReader {
 
     fun getLostPost(id: Long): LostPostEntity
 
-    fun getLostPosts(command: GetSliceLostPostsCommand): Slice<LostPostEntity>
+    fun getLostPosts(command: GetSliceLostPostsCommand): List<LostPostEntity>
 
     fun getRecommendLostPosts(command: GetRecommendLostPostsCommand): List<LostPostEntity>
 

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/lost/application/service/LostPostService.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/lost/application/service/LostPostService.kt
@@ -127,8 +127,7 @@ class LostPostService(
         return PageInfoDto.of(
             data=searchLostPostsDtoList,
             pageSize=command.pageSize,
-            firstPageTokenFunction=SearchLostPostsDto.Response::createdAt,
-            secondPageTokenFunction=SearchLostPostsDto.Response::id
+            arrayOf(SearchLostPostsDto.Response::createdAt, SearchLostPostsDto.Response::id)
         )
     }
 

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/lost/application/service/LostPostService.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/lost/application/service/LostPostService.kt
@@ -54,7 +54,7 @@ class LostPostService(
 
     private fun getRecommendPosts(subwayLine: SubwayLineEntity?, category:CategoryEntity?): List<LostPostEntity> {
         if (subwayLine === null || category === null) {
-            throw BusinessException(ResponseCode.IMPOSSIBLE_RECOMMEND_LOST_POST)
+            return listOf()
         }
 
         val command = GetRecommendLostPostsCommand.from(DEFAULT_RECOMMEND_SIZE, subwayLine, category)

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/lost/application/service/command/in/CreateLostPostCommand.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/lost/application/service/command/in/CreateLostPostCommand.kt
@@ -4,11 +4,11 @@ import backend.team.ahachul_backend.api.lost.domain.model.LostType
 import org.springframework.web.multipart.MultipartFile
 
 class CreateLostPostCommand(
+    // TODO 교환 희망 장소, 분실 세부 장소
     val title: String,
     val content: String,
     val subwayLine: Long,
     val lostType: LostType,
     val categoryName: String,
     var imageFiles: List<MultipartFile>? = listOf()
-) {
-}
+)

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/lost/application/service/command/in/SearchLostPostCommand.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/lost/application/service/command/in/SearchLostPostCommand.kt
@@ -1,12 +1,10 @@
 package backend.team.ahachul_backend.api.lost.application.service.command.`in`
 
-import backend.team.ahachul_backend.api.lost.domain.model.LostOrigin
 import backend.team.ahachul_backend.api.lost.domain.model.LostType
 import org.springframework.data.domain.Pageable
 
 class SearchLostPostCommand(
     val lostType: LostType,
-    val lostOrigin: LostOrigin?,
     val subwayLineId: Long?,
     val keyword: String?,
     val pageable: Pageable

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/lost/application/service/command/in/SearchLostPostCommand.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/lost/application/service/command/in/SearchLostPostCommand.kt
@@ -1,11 +1,14 @@
 package backend.team.ahachul_backend.api.lost.application.service.command.`in`
 
+import backend.team.ahachul_backend.api.lost.domain.model.LostOrigin
 import backend.team.ahachul_backend.api.lost.domain.model.LostType
-import org.springframework.data.domain.Pageable
 
 class SearchLostPostCommand(
     val lostType: LostType,
+    val lostOrigin: LostOrigin,
     val subwayLineId: Long?,
+    val category: String?,
     val keyword: String?,
-    val pageable: Pageable
+    val pageToken: String?,
+    val pageSize: Int
 )

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/lost/application/service/command/out/GetSliceLostPostsCommand.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/lost/application/service/command/out/GetSliceLostPostsCommand.kt
@@ -23,7 +23,7 @@ class GetSliceLostPostsCommand(
             command: SearchLostPostCommand, subwayLine: SubwayLineEntity?, category: CategoryEntity?
         ): GetSliceLostPostsCommand {
             val pageToken = command.pageToken?.let {
-                PageTokenUtils.decodePageToken(it, LocalDateTime::class.java, Long::class.java)
+                PageTokenUtils.decodePageToken(it, listOf(LocalDateTime::class.java, Long::class.java))
             }
 
             return GetSliceLostPostsCommand(
@@ -32,8 +32,8 @@ class GetSliceLostPostsCommand(
                 subwayLine = subwayLine,
                 category = category,
                 keyword = command.keyword,
-                date = pageToken?.first,
-                lostPostId = pageToken?.second,
+                date = pageToken?.get(0) as LocalDateTime?,
+                lostPostId = pageToken?.get(1) as Long?,
                 pageSize = command.pageSize,
             )
         }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/lost/application/service/command/out/GetSliceLostPostsCommand.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/lost/application/service/command/out/GetSliceLostPostsCommand.kt
@@ -8,7 +8,6 @@ import org.springframework.data.domain.Pageable
 
 class GetSliceLostPostsCommand(
     val lostType: LostType,
-    val lostOrigin: LostOrigin?,
     val subwayLine: SubwayLineEntity?,
     val keyword: String?,
     val pageable: Pageable
@@ -17,7 +16,6 @@ class GetSliceLostPostsCommand(
         fun from(command: SearchLostPostCommand, subwayLine: SubwayLineEntity?): GetSliceLostPostsCommand {
             return GetSliceLostPostsCommand(
                 lostType = command.lostType,
-                lostOrigin = command.lostOrigin,
                 subwayLine = subwayLine,
                 keyword = command.keyword,
                 pageable = command.pageable

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/lost/application/service/command/out/GetSliceLostPostsCommand.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/lost/application/service/command/out/GetSliceLostPostsCommand.kt
@@ -1,24 +1,40 @@
 package backend.team.ahachul_backend.api.lost.application.service.command.out
 
 import backend.team.ahachul_backend.api.lost.application.service.command.`in`.SearchLostPostCommand
+import backend.team.ahachul_backend.api.lost.domain.entity.CategoryEntity
 import backend.team.ahachul_backend.api.lost.domain.model.LostOrigin
 import backend.team.ahachul_backend.api.lost.domain.model.LostType
 import backend.team.ahachul_backend.common.domain.entity.SubwayLineEntity
-import org.springframework.data.domain.Pageable
+import backend.team.ahachul_backend.common.utils.PageTokenUtils
+import java.time.LocalDateTime
 
 class GetSliceLostPostsCommand(
     val lostType: LostType,
+    val lostOrigin: LostOrigin,
     val subwayLine: SubwayLineEntity?,
+    val category: CategoryEntity?,
     val keyword: String?,
-    val pageable: Pageable
+    val date: LocalDateTime?,
+    val lostPostId: Long?,
+    val pageSize : Int
 ) {
     companion object {
-        fun from(command: SearchLostPostCommand, subwayLine: SubwayLineEntity?): GetSliceLostPostsCommand {
+        fun from(
+            command: SearchLostPostCommand, subwayLine: SubwayLineEntity?, category: CategoryEntity?
+        ): GetSliceLostPostsCommand {
+            val pageToken = command.pageToken?.let {
+                PageTokenUtils.decodePageToken(it, LocalDateTime::class.java, Long::class.java)
+            }
+
             return GetSliceLostPostsCommand(
                 lostType = command.lostType,
+                lostOrigin = command.lostOrigin,
                 subwayLine = subwayLine,
+                category = category,
                 keyword = command.keyword,
-                pageable = command.pageable
+                date = pageToken?.first,
+                lostPostId = pageToken?.second,
+                pageSize = command.pageSize,
             )
         }
     }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/lost/domain/entity/LostPostEntity.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/lost/domain/entity/LostPostEntity.kt
@@ -17,8 +17,8 @@ import java.time.format.DateTimeFormatter
 
 @Entity
 @Table(indexes = [
-    Index(name = "received_date_idx", columnList = "receivedDate"),
-    Index(name = "received_date_desc_idx", columnList = "receivedDate")
+    Index(name = "received_date_desc_idx", columnList = "receivedDate"),
+    Index(name = "created_date_desc_idx", columnList = "createdDate")
 ])
 class LostPostEntity(
 

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/lost/domain/entity/LostPostEntity.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/lost/domain/entity/LostPostEntity.kt
@@ -16,7 +16,10 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 @Entity
-@Table(indexes = [Index(name = "received_date_idx", columnList = "receivedDate")])
+@Table(indexes = [
+    Index(name = "received_date_idx", columnList = "receivedDate"),
+    Index(name = "received_date_desc_idx", columnList = "receivedDate")
+])
 class LostPostEntity(
 
     @Id
@@ -128,7 +131,7 @@ class LostPostEntity(
 
     val date: LocalDateTime
         get() = when (origin) {
-            LostOrigin.LOST112 -> receivedDate!!
+            LostOrigin.LOST112 -> receivedDate
             else -> createdAt
         }
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/lost/domain/entity/LostPostEntity.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/lost/domain/entity/LostPostEntity.kt
@@ -17,8 +17,8 @@ import java.time.format.DateTimeFormatter
 
 @Entity
 @Table(indexes = [
-    Index(name = "received_date_desc_idx", columnList = "receivedDate"),
-    Index(name = "created_date_desc_idx", columnList = "createdDate")
+    Index(name = "received_date_desc_idx", columnList = "receivedDate DESC"),
+    Index(name = "created_date_desc_idx", columnList = "createdAt DESC")
 ])
 class LostPostEntity(
 

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/constant/CommonConstant.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/constant/CommonConstant.kt
@@ -9,5 +9,6 @@ class CommonConstant {
         const val LOST_FILE_URL = "/home/all.json"
         val HASHTAG_FILE_URL = "${System.getProperty("user.dir")}/logs/archive/hashtag/hashtag_log.log"
         val HASHTAG_LOG_DATETIME_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("yy-MM-dd HH:mm:ss")
+        val CURSOR_PAGING_DATETIME_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
     }
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/dto/PageInfoDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/dto/PageInfoDto.kt
@@ -11,20 +11,15 @@ data class PageInfoDto<T>(
         fun <T> of(
             data: List<T>,
             pageSize: Int,
-            firstPageTokenFunction: (T) -> Any,
-            secondPageTokenFunction: (T) -> Any
+            tokenFunctions: Array<(T) -> Any>
         ): PageInfoDto<T> {
             if (data.size <= pageSize) {
                 return PageInfoDto(null, data, false)
             }
 
             val lastValue = data[pageSize - 1]
-            val pageToken = PageTokenUtils.encodePageToken(
-                Pair(
-                    firstPageTokenFunction(lastValue),
-                    secondPageTokenFunction(lastValue)
-                )
-            )
+            val pageTokenValues = tokenFunctions.map { it(lastValue) }
+            val pageToken = PageTokenUtils.encodePageToken(*pageTokenValues.toTypedArray())
 
             return PageInfoDto(pageToken, data.subList(0, pageSize), true)
         }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/dto/PageInfoDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/dto/PageInfoDto.kt
@@ -1,0 +1,32 @@
+package backend.team.ahachul_backend.common.dto
+
+import backend.team.ahachul_backend.common.utils.PageTokenUtils
+
+data class PageInfoDto<T>(
+    val pageToken: String?,
+    val data: List<T>,
+    val hasNext: Boolean
+) {
+    companion object {
+        fun <T> of(
+            data: List<T>,
+            pageSize: Int,
+            firstPageTokenFunction: (T) -> Any,
+            secondPageTokenFunction: (T) -> Any
+        ): PageInfoDto<T> {
+            if (data.size <= pageSize) {
+                return PageInfoDto(null, data, false)
+            }
+
+            val lastValue = data[pageSize - 1]
+            val pageToken = PageTokenUtils.encodePageToken(
+                Pair(
+                    firstPageTokenFunction(lastValue),
+                    secondPageTokenFunction(lastValue)
+                )
+            )
+
+            return PageInfoDto(pageToken, data.subList(0, pageSize), true)
+        }
+    }
+}

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/utils/PageTokenUtils.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/utils/PageTokenUtils.kt
@@ -1,25 +1,22 @@
 package backend.team.ahachul_backend.common.utils
 
-import backend.team.ahachul_backend.common.constant.CommonConstant.Companion.CURSOR_PAGING_DATETIME_FORMATTER
+import backend.team.ahachul_backend.common.constant.CommonConstant
 import org.apache.commons.codec.binary.Base64
-import org.slf4j.helpers.MessageFormatter
 import java.nio.charset.StandardCharsets
 import java.time.LocalDateTime
 
 object PageTokenUtils {
 
-    private const val PAGE_TOKEN_FORMAT = "{}|{}"
-
-    fun <T, R> encodePageToken(data: Pair<T, R>): String {
-        val formatted = MessageFormatter.arrayFormat(PAGE_TOKEN_FORMAT, arrayOf(data.first.toString(), data.second.toString())).message
+    fun <T : Any> encodePageToken(vararg data: T): String {
+        val formatted = data.joinToString("|") { it.toString() }
         return Base64.encodeBase64URLSafeString(formatted.toByteArray(StandardCharsets.UTF_8))
     }
 
-    fun <T, R> decodePageToken(pageToken: String, firstType: Class<T>, secondType: Class<R>): Pair<T, R> {
+    fun decodePageToken(pageToken: String, types: List<Class<*>>): List<Any> {
         val decoded = String(Base64.decodeBase64(pageToken), StandardCharsets.UTF_8)
-        val parts = decoded.split("|", limit = 2)
-        require(parts.size == 2) { "invalid pageToken" }
-        return Pair(stringToValue(parts[0], firstType), stringToValue(parts[1], secondType))
+        val parts = decoded.split("|")
+        require(parts.size == types.size) { "invalid pageToken format" }
+        return parts.mapIndexed { index, part -> stringToValue(part, types[index]) }
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -29,7 +26,7 @@ object PageTokenUtils {
             Int::class.java -> data.toInt() as T
             Long::class.java -> data.toLong() as T
             Boolean::class.java -> data.toBoolean() as T
-            LocalDateTime::class.java -> LocalDateTime.parse(data, CURSOR_PAGING_DATETIME_FORMATTER) as T
+            LocalDateTime::class.java -> LocalDateTime.parse(data, CommonConstant.CURSOR_PAGING_DATETIME_FORMATTER) as T
             else -> throw IllegalArgumentException("unsupported type - type: $clazz")
         }
     }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/utils/PageTokenUtils.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/utils/PageTokenUtils.kt
@@ -1,0 +1,39 @@
+package backend.team.ahachul_backend.common.utils
+
+import org.apache.commons.codec.binary.Base64
+import org.slf4j.helpers.MessageFormatter
+import java.nio.charset.StandardCharsets
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+object PageTokenUtils {
+
+    private const val PAGE_TOKEN_FORMAT = "{}|{}"
+
+    fun <T, R> encodePageToken(data: Pair<T, R>): String {
+        val formatted = MessageFormatter.arrayFormat(PAGE_TOKEN_FORMAT, arrayOf(data.first.toString(), data.second.toString())).message
+        return Base64.encodeBase64URLSafeString(formatted.toByteArray(StandardCharsets.UTF_8))
+    }
+
+    fun <T, R> decodePageToken(pageToken: String, firstType: Class<T>, secondType: Class<R>): Pair<T, R> {
+        val decoded = String(Base64.decodeBase64(pageToken), StandardCharsets.UTF_8)
+        val parts = decoded.split("|", limit = 2)
+        require(parts.size == 2) { "invalid pageToken" }
+        return Pair(stringToValue(parts[0], firstType), stringToValue(parts[1], secondType))
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> stringToValue(data: String, clazz: Class<T>): T {
+        return when (clazz) {
+            String::class.java -> data as T
+            Int::class.java -> data.toInt() as T
+            Long::class.java -> data.toLong() as T
+            Boolean::class.java -> data.toBoolean() as T
+            LocalDateTime::class.java -> LocalDateTime.parse(
+                data,
+                DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
+            ) as T
+            else -> throw IllegalArgumentException("unsupported type - type: $clazz")
+        }
+    }
+}

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/utils/PageTokenUtils.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/utils/PageTokenUtils.kt
@@ -1,10 +1,10 @@
 package backend.team.ahachul_backend.common.utils
 
+import backend.team.ahachul_backend.common.constant.CommonConstant.Companion.CURSOR_PAGING_DATETIME_FORMATTER
 import org.apache.commons.codec.binary.Base64
 import org.slf4j.helpers.MessageFormatter
 import java.nio.charset.StandardCharsets
 import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 
 object PageTokenUtils {
 
@@ -29,10 +29,7 @@ object PageTokenUtils {
             Int::class.java -> data.toInt() as T
             Long::class.java -> data.toLong() as T
             Boolean::class.java -> data.toBoolean() as T
-            LocalDateTime::class.java -> LocalDateTime.parse(
-                data,
-                DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
-            ) as T
+            LocalDateTime::class.java -> LocalDateTime.parse(data, CURSOR_PAGING_DATETIME_FORMATTER) as T
             else -> throw IllegalArgumentException("unsupported type - type: $clazz")
         }
     }

--- a/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/lost/adapter/web/in/LostPostControllerDocsTest.kt
+++ b/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/lost/adapter/web/in/LostPostControllerDocsTest.kt
@@ -124,8 +124,7 @@ class LostPostControllerDocsTest: CommonDocsTestConfig() {
                 categoryName = "휴대폰"
             )),
             pageSize=1,
-            firstPageTokenFunction=SearchLostPostsDto.Response::createdAt,
-            secondPageTokenFunction=SearchLostPostsDto.Response::id
+            arrayOf(SearchLostPostsDto.Response::createdAt, SearchLostPostsDto.Response::id)
         )
         given(lostPostUseCase.searchLostPosts(any()))
             .willReturn(response)

--- a/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/lost/application/service/LostPostServiceTest.kt
+++ b/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/lost/application/service/LostPostServiceTest.kt
@@ -347,7 +347,6 @@ class LostPostServiceTest(
         return SearchLostPostCommand(
             lostType = LostType.ACQUIRE,
             subwayLineId = subwayLineId,
-            lostOrigin = null,
             keyword = keyword,
             pageable = PageRequest.of(pageSize, 3)
         )

--- a/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/lost/application/service/LostPostServiceTest.kt
+++ b/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/lost/application/service/LostPostServiceTest.kt
@@ -7,6 +7,7 @@ import backend.team.ahachul_backend.api.lost.application.service.command.`in`.Cr
 import backend.team.ahachul_backend.api.lost.application.service.command.`in`.SearchLostPostCommand
 import backend.team.ahachul_backend.api.lost.application.service.command.`in`.UpdateLostPostCommand
 import backend.team.ahachul_backend.api.lost.domain.entity.CategoryEntity
+import backend.team.ahachul_backend.api.lost.domain.model.LostOrigin
 import backend.team.ahachul_backend.api.lost.domain.model.LostPostType
 import backend.team.ahachul_backend.api.lost.domain.model.LostStatus
 import backend.team.ahachul_backend.api.lost.domain.model.LostType
@@ -28,7 +29,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.data.domain.PageRequest
 
 
 class LostPostServiceTest(
@@ -88,24 +88,24 @@ class LostPostServiceTest(
             lostPostUseCase.createLostPost(createCommand)
         }
 
-        val searchCommand1 = createSearchLostPostCommand(0, subwayLine.id, null)
-        val searchCommand2 = createSearchLostPostCommand(1, subwayLine.id, null)
-
         // when
+        val searchCommand1 = createSearchLostPostCommand(null, subwayLine.id, null)
         val response1 = lostPostUseCase.searchLostPosts(searchCommand1)
+
+        val searchCommand2 = createSearchLostPostCommand(response1.pageToken, subwayLine.id, null)
         val response2 = lostPostUseCase.searchLostPosts(searchCommand2)
 
         // then
         assertThat(response1.hasNext).isEqualTo(true)
-        assertThat(response1.posts.size).isEqualTo(3)
-        assertThat(response1.posts)
+        assertThat(response1.data.size).isEqualTo(3)
+        assertThat(response1.data)
             .extracting("content")
             .usingRecursiveComparison()
             .isEqualTo((5 downTo 3).map { "유실물$it" })
 
         assertThat(response2.hasNext).isEqualTo(false)
-        assertThat(response2.posts.size).isEqualTo(2)
-        assertThat(response2.posts)
+        assertThat(response2.data.size).isEqualTo(2)
+        assertThat(response2.data)
             .extracting("content")
             .usingRecursiveComparison()
             .isEqualTo((2 downTo 1).map { "유실물$it" })
@@ -126,15 +126,15 @@ class LostPostServiceTest(
             lostPostUseCase.createLostPost(createCommand2)
         }
 
-        val searchCommand = createSearchLostPostCommand(0, subwayLine1.id, null)
+        val searchCommand = createSearchLostPostCommand(null, subwayLine1.id, null)
 
         // when
         val response = lostPostUseCase.searchLostPosts(searchCommand)
 
         // then
-        assertThat(response.posts.size).isEqualTo(3)
-        assertThat(response.posts)
-            .extracting("subwayLine")
+        assertThat(response.data.size).isEqualTo(3)
+        assertThat(response.data)
+            .extracting("subwayLineId")
             .usingRecursiveComparison()
             .isEqualTo((1.. 3).map {subwayLine1.id}.toList())
     }
@@ -301,19 +301,21 @@ class LostPostServiceTest(
     @DisplayName("제목이나 내용에 검색 키워드가 포함된 유실물을 반환한다.")
     fun searchLostPostByKeyword() {
         // given
-        val createCommand1 = createLostPostCommand(subwayLine.id, "오늘 1호선에서 지갑을 주웠어요", "휴대폰")
-        val createCommand2 = createLostPostCommand(subwayLine.id, "2호선에서 분실물 주웠는데 찾아가세요", "휴대폰")
+        val categoryName = "휴대폰"
+        val createCommand1 = createLostPostCommand(subwayLine.id, "오늘 1호선에서 지갑을 주웠어요", categoryName)
+        val createCommand2 = createLostPostCommand(subwayLine.id, "2호선에서 분실물 주웠는데 찾아가세요", categoryName)
+
         val entity1 = lostPostUseCase.createLostPost(createCommand1)
         val entity2 = lostPostUseCase.createLostPost(createCommand2)
-        val searchCommand = createSearchLostPostCommand(0, subwayLine.id, "지갑")
+        val searchCommand = createSearchLostPostCommand(null, subwayLine.id, "지갑")
 
         // when
         val response = lostPostUseCase.searchLostPosts(searchCommand)
 
         // then
-        assertThat(response.posts.size).isEqualTo(2)
-        assertThat(response.posts[0].id).isEqualTo(entity2.id)
-        assertThat(response.posts[1].id).isEqualTo(entity1.id)
+        assertThat(response.data.size).isEqualTo(2)
+        assertThat(response.data[0].id).isEqualTo(entity2.id)
+        assertThat(response.data[1].id).isEqualTo(entity1.id)
     }
     
     private fun createLostPostCommand(subwayLineId: Long, content: String, categoryName: String): CreateLostPostCommand {
@@ -322,7 +324,7 @@ class LostPostServiceTest(
             content = content,
             subwayLine = subwayLineId,
             lostType = LostType.ACQUIRE,
-            categoryName = categoryName
+            categoryName = categoryName,
         )
     }
 
@@ -343,12 +345,15 @@ class LostPostServiceTest(
         )
     }
 
-    private fun createSearchLostPostCommand(pageSize: Int, subwayLineId:Long, keyword:String?): SearchLostPostCommand {
+    private fun createSearchLostPostCommand(pageToken: String?, subwayLineId:Long, keyword:String?): SearchLostPostCommand {
         return SearchLostPostCommand(
             lostType = LostType.ACQUIRE,
+            lostOrigin = LostOrigin.AHACHUL,
             subwayLineId = subwayLineId,
             keyword = keyword,
-            pageable = PageRequest.of(pageSize, 3)
+            category = "휴대폰",
+            pageToken = pageToken,
+            pageSize = 3
         )
     }
 }


### PR DESCRIPTION
## 📚 개요
+ #222

## ✏️ 작업 내용
커서 기반 페이징 방식을 수정했습니다.
 
1. 정렬 대상 수정
  + Lost112에서 가져온 데이터 : `recievedDate` 기준으로 정렬
  + 아하철에서 등록한 데이터 : `createdDate` 기준으로 정렬하도록

2. 페이징 관련 공통 클래스 생성
  + 커뮤니티 쪽도 나중에 커서 기반으로 변경하면 좋을 것 같아서 `PageInfoDto` 를 생성해 재사용 할 수 있도록 했습니다.

## 💡 주의 사항
+ 논의 사항을 작성해 주세요.
+ 중점적으로 리뷰받고 싶은 내용을 작성해 주세요.
