### PR TITLE
카카오, 구글 로그인 작동하도록 수정

### DIFF
--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/AuthController.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/AuthController.kt
@@ -24,15 +24,21 @@ class AuthController(
 ) {
 
     @GetMapping("/v1/auth/redirect-url")
-    fun getRedirectUrl(@RequestParam providerType: ProviderType): CommonResponse<GetRedirectUrlDto.Response> {
-        return CommonResponse.success(authUseCase.getRedirectUrl(GetRedirectUrlCommand(providerType)))
+    fun getRedirectUrl(@RequestHeader(value="Origin") origin: String?, @RequestParam providerType: ProviderType): CommonResponse<GetRedirectUrlDto.Response> {
+        if (origin == null) {
+            throw CommonException(ResponseCode.BAD_REQUEST);
+        } else {
+            return CommonResponse.success(authUseCase.getRedirectUrl(GetRedirectUrlCommand(origin, providerType)))
+        }
     }
 
     @PostMapping("/v1/auth/login")
     fun login(@RequestHeader(value="Origin") origin: String?, @RequestBody request: LoginMemberDto.Request): CommonResponse<LoginMemberDto.Response> {
-        // TODO 개발용 코드. 추후 삭제
-        oAuthProperties.client[request.providerType.toString().lowercase()]!!.redirectUri = "$origin/onboarding/redirect?type=${request.providerType}"
-        return CommonResponse.success(authUseCase.login(request.toCommand()))
+        if (origin == null) {
+            throw CommonException(ResponseCode.BAD_REQUEST);
+        } else {
+            return CommonResponse.success(authUseCase.login(request.toCommand(origin)))
+        }
     }
 
     @PostMapping("/v1/auth/token/refresh")

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/AuthController.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/AuthController.kt
@@ -7,7 +7,6 @@ import backend.team.ahachul_backend.api.member.application.port.`in`.AuthUseCase
 import backend.team.ahachul_backend.api.member.application.port.`in`.command.GetRedirectUrlCommand
 import backend.team.ahachul_backend.api.member.domain.model.ProviderType
 import backend.team.ahachul_backend.common.exception.CommonException
-import backend.team.ahachul_backend.common.properties.OAuthProperties
 import backend.team.ahachul_backend.common.response.CommonResponse
 import backend.team.ahachul_backend.common.response.ResponseCode
 import io.jsonwebtoken.ExpiredJwtException
@@ -18,27 +17,32 @@ import org.springframework.web.bind.annotation.*
 
 @RestController
 class AuthController(
-        private val authUseCase: AuthUseCase,
-
-        private val oAuthProperties: OAuthProperties,
+    private val authUseCase: AuthUseCase,
 ) {
-
-    @GetMapping("/v1/auth/redirect-url")
-    fun getRedirectUrl(@RequestHeader(value="Origin") origin: String?, @RequestParam providerType: ProviderType): CommonResponse<GetRedirectUrlDto.Response> {
+    fun verifyOrigin(origin: String?) {
         if (origin == null) {
-            throw CommonException(ResponseCode.BAD_REQUEST);
-        } else {
-            return CommonResponse.success(authUseCase.getRedirectUrl(GetRedirectUrlCommand(origin, providerType)))
+            throw CommonException(ResponseCode.BAD_REQUEST)
         }
     }
 
+    @GetMapping("/v1/auth/redirect-url")
+    fun getRedirectUrl(
+        @RequestHeader(value = "Origin") origin: String?,
+        @RequestParam providerType: ProviderType
+    ): CommonResponse<GetRedirectUrlDto.Response> {
+        verifyOrigin(origin)
+
+        return CommonResponse.success(authUseCase.getRedirectUrl(GetRedirectUrlCommand(origin!!, providerType)))
+    }
+
     @PostMapping("/v1/auth/login")
-    fun login(@RequestHeader(value="Origin") origin: String?, @RequestBody request: LoginMemberDto.Request): CommonResponse<LoginMemberDto.Response> {
-        if (origin == null) {
-            throw CommonException(ResponseCode.BAD_REQUEST);
-        } else {
-            return CommonResponse.success(authUseCase.login(request.toCommand(origin)))
-        }
+    fun login(
+        @RequestHeader(value = "Origin") origin: String?,
+        @RequestBody request: LoginMemberDto.Request
+    ): CommonResponse<LoginMemberDto.Response> {
+        verifyOrigin(origin)
+
+        return CommonResponse.success(authUseCase.login(request.toCommand(origin!!)))
     }
 
     @PostMapping("/v1/auth/token/refresh")
@@ -47,7 +51,10 @@ class AuthController(
             return CommonResponse.success(authUseCase.getToken(request.toCommand()))
         } catch (e: Exception) {
             throw when (e) {
-                is SignatureException, is UnsupportedJwtException, is IllegalArgumentException, is MalformedJwtException -> CommonException(ResponseCode.INVALID_REFRESH_TOKEN)
+                is SignatureException, is UnsupportedJwtException, is IllegalArgumentException, is MalformedJwtException -> CommonException(
+                    ResponseCode.INVALID_REFRESH_TOKEN
+                )
+
                 is ExpiredJwtException -> CommonException(ResponseCode.EXPIRED_REFRESH_TOKEN)
                 else -> CommonException(ResponseCode.INTERNAL_SERVER_ERROR)
             }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/dto/LoginMemberDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/dto/LoginMemberDto.kt
@@ -11,8 +11,9 @@ class LoginMemberDto {
             @NotNull
             val providerCode: String
     ) {
-        fun toCommand(): LoginMemberCommand {
+        fun toCommand(originHost:String): LoginMemberCommand {
             return LoginMemberCommand(
+                    originHost = originHost,
                     providerType = providerType,
                     providerCode = providerCode
             )

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/in/command/GetRedirectUrlCommand.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/in/command/GetRedirectUrlCommand.kt
@@ -3,6 +3,7 @@ package backend.team.ahachul_backend.api.member.application.port.`in`.command
 import backend.team.ahachul_backend.api.member.domain.model.ProviderType
 
 class GetRedirectUrlCommand(
+        val originHost: String,
         val providerType: ProviderType
 ) {
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/in/command/LoginMemberCommand.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/in/command/LoginMemberCommand.kt
@@ -3,6 +3,7 @@ package backend.team.ahachul_backend.api.member.application.port.`in`.command
 import backend.team.ahachul_backend.api.member.domain.model.ProviderType
 
 data class LoginMemberCommand(
+        val originHost: String,
         val providerCode: String,
         val providerType: ProviderType
 ) {

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/GoogleMemberClient.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/GoogleMemberClient.kt
@@ -4,7 +4,7 @@ import backend.team.ahachul_backend.common.dto.GoogleUserInfoDto
 
 interface GoogleMemberClient {
 
-    fun getAccessTokenByCode(code: String): String
+    fun getAccessTokenByCode(code: String, redirectUri: String): String
 
     fun getMemberInfoByAccessToken(accessToken: String): GoogleUserInfoDto
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/KakaoMemberClient.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/KakaoMemberClient.kt
@@ -4,7 +4,7 @@ import backend.team.ahachul_backend.common.dto.KakaoMemberInfoDto
 
 interface KakaoMemberClient {
 
-    fun getAccessTokenByCode(code: String): String
+    fun getAccessTokenByCode(code: String, redirectUri: String): String
 
     fun getMemberInfoByAccessToken(accessToken: String): KakaoMemberInfoDto
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/impl/GoogleMemberClientImpl.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/impl/GoogleMemberClientImpl.kt
@@ -27,11 +27,11 @@ class GoogleMemberClientImpl(
     private val provider :OAuthProperties.Provider =  oAuthProperties.provider[PROVIDER]!!
     val objectMapper: ObjectMapper = ObjectMapper()
 
-    override fun getAccessTokenByCode(code: String): String {
+    override fun getAccessTokenByCode(code: String, redirectUri: String): String {
         val headers = HttpHeaders().apply {
             contentType = MediaType.APPLICATION_FORM_URLENCODED
         }
-        val httpEntity = HttpEntity(getHttpBodyParams(code), headers)
+        val httpEntity = HttpEntity(getHttpBodyParams(code, redirectUri), headers)
         val response = restTemplate.exchange(provider.tokenUri, HttpMethod.POST, httpEntity, String::class.java)
 
         if (response.statusCode == HttpStatus.OK) {
@@ -40,12 +40,12 @@ class GoogleMemberClientImpl(
         throw CommonException(ResponseCode.INVALID_OAUTH_AUTHORIZATION_CODE)
     }
 
-    private fun getHttpBodyParams(code: String): LinkedMultiValueMap<String, String?>{
+    private fun getHttpBodyParams(code: String, redirectUri: String): LinkedMultiValueMap<String, String?>{
         val params = LinkedMultiValueMap<String, String?>()
         params["code"] = code
         params["client_id"] = client.clientId
         params["client_secret"] = client.clientSecret
-        params["redirect_uri"] = client.redirectUri
+        params["redirect_uri"] = redirectUri
         params["grant_type"] = "authorization_code"
         return params
     }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/impl/KakaoMemberClientImpl.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/impl/KakaoMemberClientImpl.kt
@@ -24,7 +24,7 @@ class KakaoMemberClientImpl(
         private val oAuthProperties: OAuthProperties
 ): KakaoMemberClient {
 
-    override fun getAccessTokenByCode(code: String): String {
+    override fun getAccessTokenByCode(code: String, redirectUri: String): String {
         val headers = HttpHeaders().apply {
             contentType = MediaType.APPLICATION_FORM_URLENCODED
         }
@@ -32,7 +32,7 @@ class KakaoMemberClientImpl(
         val params = LinkedMultiValueMap<String, String>()
         params.add("grant_type", "authorization_code")
         params.add("client_id", oAuthProperties.client["kakao"]!!.clientId)
-        params.add("redirect_uri", oAuthProperties.client["kakao"]!!.redirectUri)
+        params.add("redirect_uri", redirectUri)
         params.add("code", code)
 
         val request = HttpEntity(params, headers)

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/dto/GoogleUserInfoDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/dto/GoogleUserInfoDto.kt
@@ -2,13 +2,13 @@ package backend.team.ahachul_backend.common.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
 
-data class GoogleUserInfoDto (
+data class GoogleUserInfoDto(
     @JsonProperty("id") val id: String,
     @JsonProperty("email") val email: String,
     @JsonProperty("verified_email") val verifiedEmail: Boolean,
     @JsonProperty("name") val name: String,
-    @JsonProperty("given_name") val givenName: String,
-    @JsonProperty("family_name") val familyName: String,
-    @JsonProperty("picture") val picture: String,
-    @JsonProperty("locale") val locale: String
+    @JsonProperty("given_name") val givenName: String?,
+    @JsonProperty("family_name") val familyName: String?,
+    @JsonProperty("picture") val picture: String?,
+    @JsonProperty("locale") val locale: String?
 )

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/properties/OAuthProperties.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/properties/OAuthProperties.kt
@@ -13,7 +13,7 @@ class OAuthProperties(
     data class Client(
         val clientId: String,
         val clientSecret: String?,
-        var redirectUri: String,
+        var redirectUriPath: String,
         val scope: String?,
         val responseType: String,
         val accessType: String?


### PR DESCRIPTION
## 📚 개요
+ #229 

## ✏️ 작업 내용
+ auth/redirect-url API가 클라이언트의 Host에 맞는 response를 하도록 변경
+ Google userinfo API에서 특정 필드(locale)가 response에서 빠지는 경우가 존재해 사용하지 않는 필드는 nullable로 변경

## 💡 주의 사항
+ Google userinfo API에서 필요한 필드가 빠지는 경우가 있을 수 있으므로 Google API 명세 확인 필요
+ auth/redirect-url API는 oauth에서의 redirect-uri가 아닌 로그인 url을 response하는데 두 가지 용어가 다소 헷갈리네요.