### PR TITLE
✨ 애플 로그인 기능 추가 (#228)

### DIFF
--- a/ahachul_backend/.gitignore
+++ b/ahachul_backend/.gitignore
@@ -49,3 +49,7 @@ src/test/resources/
 
 ### restdocs ###
 src/main/resources/static
+
+### p8, md ###
+src/main/resources/*.p8
+src/main/resources/*.md

--- a/ahachul_backend/build.gradle.kts
+++ b/ahachul_backend/build.gradle.kts
@@ -121,6 +121,7 @@ tasks {
         into(file("src/main/resources/static/docs"))
     }
     bootJar {
+        duplicatesStrategy = DuplicatesStrategy.INCLUDE
         dependsOn("copyDocument")
         from(asciidoctor.get().outputDir) {
             into("BOOT-INF/classes/static/docs")

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/AuthController.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/AuthController.kt
@@ -19,30 +19,15 @@ import org.springframework.web.bind.annotation.*
 class AuthController(
     private val authUseCase: AuthUseCase,
 ) {
-    fun verifyOrigin(origin: String?) {
-        if (origin == null) {
-            throw CommonException(ResponseCode.BAD_REQUEST)
-        }
-    }
 
     @GetMapping("/v1/auth/redirect-url")
-    fun getRedirectUrl(
-        @RequestHeader(value = "Origin") origin: String?,
-        @RequestParam providerType: ProviderType
-    ): CommonResponse<GetRedirectUrlDto.Response> {
-        verifyOrigin(origin)
-
-        return CommonResponse.success(authUseCase.getRedirectUrl(GetRedirectUrlCommand(origin!!, providerType)))
+    fun getRedirectUrl(@RequestHeader(value = "Origin") origin: String?, @RequestParam providerType: ProviderType): CommonResponse<GetRedirectUrlDto.Response> {
+        return CommonResponse.success(authUseCase.getRedirectUrl(GetRedirectUrlCommand(origin, providerType)))
     }
 
     @PostMapping("/v1/auth/login")
-    fun login(
-        @RequestHeader(value = "Origin") origin: String?,
-        @RequestBody request: LoginMemberDto.Request
-    ): CommonResponse<LoginMemberDto.Response> {
-        verifyOrigin(origin)
-
-        return CommonResponse.success(authUseCase.login(request.toCommand(origin!!)))
+    fun login(@RequestHeader(value = "Origin") origin: String?, @RequestBody request: LoginMemberDto.Request): CommonResponse<LoginMemberDto.Response> {
+        return CommonResponse.success(authUseCase.login(request.toCommand(origin)))
     }
 
     @PostMapping("/v1/auth/token/refresh")
@@ -51,10 +36,7 @@ class AuthController(
             return CommonResponse.success(authUseCase.getToken(request.toCommand()))
         } catch (e: Exception) {
             throw when (e) {
-                is SignatureException, is UnsupportedJwtException, is IllegalArgumentException, is MalformedJwtException -> CommonException(
-                    ResponseCode.INVALID_REFRESH_TOKEN
-                )
-
+                is SignatureException, is UnsupportedJwtException, is IllegalArgumentException, is MalformedJwtException -> CommonException(ResponseCode.INVALID_REFRESH_TOKEN)
                 is ExpiredJwtException -> CommonException(ResponseCode.EXPIRED_REFRESH_TOKEN)
                 else -> CommonException(ResponseCode.INTERNAL_SERVER_ERROR)
             }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/dto/LoginMemberDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/dto/LoginMemberDto.kt
@@ -11,7 +11,7 @@ class LoginMemberDto {
             @NotNull
             val providerCode: String
     ) {
-        fun toCommand(originHost:String): LoginMemberCommand {
+        fun toCommand(originHost: String?): LoginMemberCommand {
             return LoginMemberCommand(
                     originHost = originHost,
                     providerType = providerType,

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/in/command/GetRedirectUrlCommand.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/in/command/GetRedirectUrlCommand.kt
@@ -3,7 +3,7 @@ package backend.team.ahachul_backend.api.member.application.port.`in`.command
 import backend.team.ahachul_backend.api.member.domain.model.ProviderType
 
 class GetRedirectUrlCommand(
-        val originHost: String,
+        val originHost: String?,
         val providerType: ProviderType
 ) {
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/in/command/LoginMemberCommand.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/in/command/LoginMemberCommand.kt
@@ -3,7 +3,7 @@ package backend.team.ahachul_backend.api.member.application.port.`in`.command
 import backend.team.ahachul_backend.api.member.domain.model.ProviderType
 
 data class LoginMemberCommand(
-        val originHost: String,
+        val originHost: String?,
         val providerCode: String,
         val providerType: ProviderType
 ) {

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/service/AuthService.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/application/service/AuthService.kt
@@ -136,7 +136,6 @@ class AuthService(
                         .queryParam("redirect_uri", client.redirectUri)
                         .queryParam("response_type", client.responseType)
                         .queryParam("scope", client.scope)
-                        .queryParam("response_mode", client.responseMode)
                         .build()
                         .toString()
         })

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/domain/entity/MemberEntity.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/domain/entity/MemberEntity.kt
@@ -6,6 +6,7 @@ import backend.team.ahachul_backend.api.member.domain.model.ProviderType
 
 import backend.team.ahachul_backend.api.member.domain.model.MemberStatusType
 import backend.team.ahachul_backend.api.report.domain.ReportEntity
+import backend.team.ahachul_backend.common.dto.AppleUserInfoDto
 import backend.team.ahachul_backend.common.dto.GoogleUserInfoDto
 import backend.team.ahachul_backend.common.dto.KakaoMemberInfoDto
 import backend.team.ahachul_backend.common.entity.BaseEntity
@@ -62,6 +63,18 @@ class MemberEntity(
                         return MemberEntity(
                                 nickname = userInfo.name,
                                 providerUserId = userInfo.id,
+                                provider = command.providerType,
+                                email = userInfo.email,
+                                gender = null,
+                                ageRange = null,
+                                status = MemberStatusType.ACTIVE
+                        )
+                }
+
+                fun ofApple(command: LoginMemberCommand, userInfo: AppleUserInfoDto): MemberEntity {
+                        return MemberEntity(
+                                nickname = null,
+                                providerUserId = userInfo.sub,
                                 provider = command.providerType,
                                 email = userInfo.email,
                                 gender = null,

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/domain/model/ProviderType.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/api/member/domain/model/ProviderType.kt
@@ -2,5 +2,6 @@ package backend.team.ahachul_backend.api.member.domain.model
 
 enum class ProviderType {
     KAKAO,
-    GOOGLE
+    GOOGLE,
+    APPLE
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/AppleMemberClient.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/AppleMemberClient.kt
@@ -1,6 +1,10 @@
 package backend.team.ahachul_backend.common.client
 
-interface AppleMemberClient {
-    fun verifyIdentityToken(identityToken: String, authCode: String): Boolean
+import backend.team.ahachul_backend.common.dto.AppleUserInfoDto
 
+interface AppleMemberClient {
+
+    fun getIdTokenByCode(code: String): String
+
+    fun getMemberInfoByIdToken(idToken: String): AppleUserInfoDto
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/AppleMemberClient.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/AppleMemberClient.kt
@@ -4,7 +4,7 @@ import backend.team.ahachul_backend.common.dto.AppleUserInfoDto
 
 interface AppleMemberClient {
 
-    fun getIdTokenByCode(code: String): String
+    fun getIdTokenByCodeAndOrigin(code: String, origin: String?): String
 
     fun getMemberInfoByIdToken(idToken: String): AppleUserInfoDto
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/GoogleMemberClient.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/GoogleMemberClient.kt
@@ -4,7 +4,7 @@ import backend.team.ahachul_backend.common.dto.GoogleUserInfoDto
 
 interface GoogleMemberClient {
 
-    fun getAccessTokenByCode(code: String, redirectUri: String): String
+    fun getAccessTokenByCodeAndOrigin(code: String, origin: String?): String
 
     fun getMemberInfoByAccessToken(accessToken: String): GoogleUserInfoDto
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/KakaoMemberClient.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/KakaoMemberClient.kt
@@ -4,7 +4,7 @@ import backend.team.ahachul_backend.common.dto.KakaoMemberInfoDto
 
 interface KakaoMemberClient {
 
-    fun getAccessTokenByCode(code: String, redirectUri: String): String
+    fun getAccessTokenByCodeAndOrigin(code: String, origin: String?): String
 
     fun getMemberInfoByAccessToken(accessToken: String): KakaoMemberInfoDto
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/impl/AppleMemberClientImpl.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/impl/AppleMemberClientImpl.kt
@@ -34,17 +34,17 @@ class AppleMemberClientImpl(
         val PROVIDER = ProviderType.APPLE.toString().lowercase(Locale.getDefault())
     }
 
-    private val client : OAuthProperties.Client =  oAuthProperties.client[PROVIDER]!!
-    private val provider : OAuthProperties.Provider =  oAuthProperties.provider[PROVIDER]!!
+    private val client : OAuthProperties.Client = oAuthProperties.client[PROVIDER]!!
+    private val provider : OAuthProperties.Provider = oAuthProperties.provider[PROVIDER]!!
     private val properties : OAuthProperties.Properties = oAuthProperties.properties[PROVIDER]!!
 
     val objectMapper: ObjectMapper = ObjectMapper()
 
-    override fun getIdTokenByCode(code: String): String {
+    override fun getIdTokenByCodeAndOrigin(code: String, origin: String?): String {
         val headers = HttpHeaders().apply {
             contentType = MediaType.APPLICATION_FORM_URLENCODED
         }
-        val httpEntity = HttpEntity(getHttpBodyParams(code), headers)
+        val httpEntity = HttpEntity(getHttpBodyParams(code, origin), headers)
         val response = restTemplate.exchange(provider.tokenUri, HttpMethod.POST, httpEntity, String::class.java)
 
         if (response.statusCode == HttpStatus.OK) {
@@ -61,13 +61,13 @@ class AppleMemberClientImpl(
         return objectMapper.readValue(payload, AppleUserInfoDto::class.java)
     }
 
-    private fun getHttpBodyParams(code: String): LinkedMultiValueMap<String, String?> {
+    private fun getHttpBodyParams(code: String, origin: String?): LinkedMultiValueMap<String, String?> {
         val params = LinkedMultiValueMap<String, String?>()
 
         params["code"] = code
         params["client_id"] = client.clientId
         params["client_secret"] = getClientSecret()
-        params["redirect_uri"] = client.redirectUri
+        params["redirect_uri"] = client.getRedirectUri(origin)
         params["grant_type"] = "authorization_code"
 
         return params

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/impl/AppleMemberClientImpl.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/impl/AppleMemberClientImpl.kt
@@ -1,80 +1,109 @@
 package backend.team.ahachul_backend.common.client.impl
 
+import backend.team.ahachul_backend.api.member.domain.model.ProviderType
 import backend.team.ahachul_backend.common.client.AppleMemberClient
-import backend.team.ahachul_backend.common.dto.ApplePublicKeyDto
+import backend.team.ahachul_backend.common.dto.AppleAccessTokenDto
+import backend.team.ahachul_backend.common.dto.AppleUserInfoDto
 import backend.team.ahachul_backend.common.exception.CommonException
-import backend.team.ahachul_backend.common.logging.Logger
+import backend.team.ahachul_backend.common.properties.OAuthProperties
 import backend.team.ahachul_backend.common.response.ResponseCode
-import backend.team.ahachul_backend.common.utils.JwtUtils
 import com.fasterxml.jackson.databind.ObjectMapper
-import io.jsonwebtoken.Claims
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.SignatureAlgorithm.ES256
+import org.springframework.core.io.ClassPathResource
+import org.springframework.http.*
 import org.springframework.stereotype.Component
+import org.springframework.util.LinkedMultiValueMap
 import org.springframework.web.client.RestTemplate
-import java.math.BigInteger
-import java.security.Key
+import java.nio.file.Files
+import java.nio.file.Path
 import java.security.KeyFactory
-import java.security.spec.RSAPublicKeySpec
+import java.security.PrivateKey
+import java.security.spec.KeySpec
+import java.security.spec.PKCS8EncodedKeySpec
+import java.time.LocalDateTime
+import java.time.ZoneId
 import java.util.*
 
 @Component
 class AppleMemberClientImpl(
         private val restTemplate: RestTemplate,
-        private val jwtUtils: JwtUtils,
+        private val oAuthProperties: OAuthProperties
 ): AppleMemberClient {
-    val logger: Logger = Logger(javaClass)
+    companion object {
+        val PROVIDER = ProviderType.APPLE.toString().lowercase(Locale.getDefault())
+    }
+
+    private val client : OAuthProperties.Client =  oAuthProperties.client[PROVIDER]!!
+    private val provider : OAuthProperties.Provider =  oAuthProperties.provider[PROVIDER]!!
+    private val properties : OAuthProperties.Properties = oAuthProperties.properties[PROVIDER]!!
+
     val objectMapper: ObjectMapper = ObjectMapper()
 
-    override fun verifyIdentityToken(identityToken: String, authCode: String): Boolean {
-        if (validateIdentityToken(identityToken)) {
-            throw CommonException(ResponseCode.INVALID_APPLE_ID_TOKEN)
+    override fun getIdTokenByCode(code: String): String {
+        val headers = HttpHeaders().apply {
+            contentType = MediaType.APPLICATION_FORM_URLENCODED
         }
-        return true
-    }
+        val httpEntity = HttpEntity(getHttpBodyParams(code), headers)
+        val response = restTemplate.exchange(provider.tokenUri, HttpMethod.POST, httpEntity, String::class.java)
 
-    private fun validateIdentityToken(identityToken: String): Boolean {
-        val url = "https://appleid.apple.com/auth/keys"
-        val response = restTemplate.getForObject(url, String::class.java)
-
-        val key = objectMapper.readValue(response, ApplePublicKeyDto::class.java)
-        val header = getHeaderInfoFromIdentityToken(identityToken)
-        val public = key.getMatchedInfo(header?.get("kid") as String, header["alg"] as String)
-            ?: throw IllegalArgumentException()
-
-        return try {
-            val claim = jwtUtils.verify(identityToken, createPublicKeyByRSA(public)).body
-            validateClaimInfo(claim)
-        } catch (e: Exception) {
-            logger.error(e.message, ResponseCode.BAD_REQUEST, e.stackTraceToString())
-            false
+        if (response.statusCode == HttpStatus.OK) {
+            return objectMapper.readValue(response.body, AppleAccessTokenDto::class.java).idToken
         }
+        throw CommonException(ResponseCode.INVALID_OAUTH_AUTHORIZATION_CODE)
     }
 
-    private fun validateClaimInfo(claim: Claims): Boolean {
-        val curTime = Date(System.currentTimeMillis())
+    override fun getMemberInfoByIdToken(idToken: String): AppleUserInfoDto {
+        val tokenParts: List<String> = idToken.split(".")
 
-        return !(curTime.before(claim["exp"] as Date?)
-                || claim["iss"] == "https://appleid.apple.com"
-                || claim["aud"] == "appleAppId/clientId")
+        val payload = String(Base64.getDecoder().decode(tokenParts[1]))
+
+        return objectMapper.readValue(payload, AppleUserInfoDto::class.java)
     }
 
-    /**
-     * 헤더 부분을 잘라서 토큰 Base64로 복호화
-     */
-    private fun getHeaderInfoFromIdentityToken(token: String): Map<*, *>? {
-        val headerToken = token.substring(0, token.indexOf('.'))
-        return objectMapper.readValue(
-            String(Base64.getDecoder().decode(headerToken.toByteArray()), Charsets.UTF_8), Map::class.java)
+    private fun getHttpBodyParams(code: String): LinkedMultiValueMap<String, String?> {
+        val params = LinkedMultiValueMap<String, String?>()
+
+        params["code"] = code
+        params["client_id"] = client.clientId
+        params["client_secret"] = getClientSecret()
+        params["redirect_uri"] = client.redirectUri
+        params["grant_type"] = "authorization_code"
+
+        return params
     }
 
-    /**
-     * RSA 암호화 방식으로 public key 생성 후 권한 코드 인증
-     */
-    private fun createPublicKeyByRSA(key: ApplePublicKeyDto.Key): Key {
-        val n = BigInteger(1, Base64.getDecoder().decode(key.n))
-        val e = BigInteger(1, Base64.getDecoder().decode(key.e))
+    private fun getClientSecret(): String {
+        val now = LocalDateTime.now()
 
-        val publicKeySpec = RSAPublicKeySpec(n, e)
-        val keyFactory = KeyFactory.getInstance(key.kty)
-        return keyFactory.generatePublic(publicKeySpec)
+        return Jwts.builder()
+            .setHeaderParam("kid", properties.kid)
+            .setIssuer(properties.iss)
+            .setIssuedAt(localDateTimeToDate(now))
+            .setExpiration(localDateTimeToDate(now.plusMonths(6)))
+            .setSubject(properties.sub)
+            .setAudience(properties.aud)
+            .signWith(getKey(), ES256)
+            .compact()
+    }
+
+    private fun localDateTimeToDate(now: LocalDateTime): Date {
+        return Date.from(now.atZone(ZoneId.systemDefault()).toInstant())
+    }
+
+    private fun getKey(): PrivateKey {
+        return KeyFactory.getInstance("EC").generatePrivate(getKeySpec())
+    }
+
+    private fun getKeySpec(): KeySpec {
+        return PKCS8EncodedKeySpec(Base64.getDecoder().decode(getKeyBytes()))
+    }
+
+    private fun getKeyBytes(): ByteArray {
+        return Files.readAllBytes(getKeyFilePath())
+    }
+
+    private fun getKeyFilePath(): Path {
+        return ClassPathResource(properties.kid + ".p8").file.toPath()
     }
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/impl/GoogleMemberClientImpl.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/impl/GoogleMemberClientImpl.kt
@@ -55,7 +55,7 @@ class GoogleMemberClientImpl(
             setBearerAuth(accessToken)
         }
         val httpEntity = HttpEntity<Any>(headers)
-        val response = restTemplate.exchange(provider.userInfoUri, HttpMethod.GET, httpEntity, String::class.java)
+        val response = restTemplate.exchange(provider.userInfoUri!!, HttpMethod.GET, httpEntity, String::class.java)
 
         if (response.statusCode == HttpStatus.OK) {
             return objectMapper.readValue(response.body, GoogleUserInfoDto::class.java)

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/impl/GoogleMemberClientImpl.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/impl/GoogleMemberClientImpl.kt
@@ -27,11 +27,11 @@ class GoogleMemberClientImpl(
     private val provider :OAuthProperties.Provider =  oAuthProperties.provider[PROVIDER]!!
     val objectMapper: ObjectMapper = ObjectMapper()
 
-    override fun getAccessTokenByCode(code: String, redirectUri: String): String {
+    override fun getAccessTokenByCodeAndOrigin(code: String, origin: String?): String {
         val headers = HttpHeaders().apply {
             contentType = MediaType.APPLICATION_FORM_URLENCODED
         }
-        val httpEntity = HttpEntity(getHttpBodyParams(code, redirectUri), headers)
+        val httpEntity = HttpEntity(getHttpBodyParams(code, origin), headers)
         val response = restTemplate.exchange(provider.tokenUri, HttpMethod.POST, httpEntity, String::class.java)
 
         if (response.statusCode == HttpStatus.OK) {
@@ -40,12 +40,12 @@ class GoogleMemberClientImpl(
         throw CommonException(ResponseCode.INVALID_OAUTH_AUTHORIZATION_CODE)
     }
 
-    private fun getHttpBodyParams(code: String, redirectUri: String): LinkedMultiValueMap<String, String?>{
+    private fun getHttpBodyParams(code: String, origin: String?): LinkedMultiValueMap<String, String?>{
         val params = LinkedMultiValueMap<String, String?>()
         params["code"] = code
         params["client_id"] = client.clientId
         params["client_secret"] = client.clientSecret
-        params["redirect_uri"] = redirectUri
+        params["redirect_uri"] = client.getRedirectUri(origin)
         params["grant_type"] = "authorization_code"
         return params
     }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/impl/KakaoMemberClientImpl.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/impl/KakaoMemberClientImpl.kt
@@ -1,5 +1,6 @@
 package backend.team.ahachul_backend.common.client.impl
 
+import backend.team.ahachul_backend.api.member.domain.model.ProviderType
 import backend.team.ahachul_backend.common.client.KakaoMemberClient
 import backend.team.ahachul_backend.common.dto.KakaoAccessTokenDto
 import backend.team.ahachul_backend.common.dto.KakaoMemberInfoDto
@@ -16,27 +17,34 @@ import org.springframework.stereotype.Component
 import org.springframework.util.LinkedMultiValueMap
 import org.springframework.util.MultiValueMap
 import org.springframework.web.client.RestTemplate
+import java.util.*
 
 @Component
 class KakaoMemberClientImpl(
         private val restTemplate: RestTemplate,
         private val objectMapper: ObjectMapper,
-        private val oAuthProperties: OAuthProperties
+        oAuthProperties: OAuthProperties
 ): KakaoMemberClient {
+    companion object {
+        val PROVIDER = ProviderType.KAKAO.toString().lowercase(Locale.getDefault())
+    }
 
-    override fun getAccessTokenByCode(code: String, redirectUri: String): String {
+    private val client : OAuthProperties.Client = oAuthProperties.client[PROVIDER]!!
+    private val provider : OAuthProperties.Provider = oAuthProperties.provider[PROVIDER]!!
+
+    override fun getAccessTokenByCodeAndOrigin(code: String, origin: String?): String {
         val headers = HttpHeaders().apply {
             contentType = MediaType.APPLICATION_FORM_URLENCODED
         }
 
         val params = LinkedMultiValueMap<String, String>()
         params.add("grant_type", "authorization_code")
-        params.add("client_id", oAuthProperties.client["kakao"]!!.clientId)
-        params.add("redirect_uri", redirectUri)
+        params.add("client_id", client.clientId)
+        params.add("redirect_uri", client.getRedirectUri(origin))
         params.add("code", code)
 
         val request = HttpEntity(params, headers)
-        val url = oAuthProperties.provider["kakao"]!!.tokenUri
+        val url = provider.tokenUri
 
         val response = restTemplate.exchange(url, HttpMethod.POST, request, String::class.java)
         return objectMapper.readValue(response.body, KakaoAccessTokenDto::class.java).accessToken
@@ -50,10 +58,8 @@ class KakaoMemberClientImpl(
 
         val request = HttpEntity<MultiValueMap<String, String>>(params, headers)
 
-        val url = oAuthProperties.provider["kakao"]!!.userInfoUri
-
         val response = restTemplate.exchange(
-                url!!,
+                provider.userInfoUri!!,
                 HttpMethod.GET,
                 request,
                 String::class.java

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/impl/KakaoMemberClientImpl.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/client/impl/KakaoMemberClientImpl.kt
@@ -53,7 +53,7 @@ class KakaoMemberClientImpl(
         val url = oAuthProperties.provider["kakao"]!!.userInfoUri
 
         val response = restTemplate.exchange(
-                url,
+                url!!,
                 HttpMethod.GET,
                 request,
                 String::class.java

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/dto/AppleAccessTokenDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/dto/AppleAccessTokenDto.kt
@@ -1,10 +1,11 @@
 package backend.team.ahachul_backend.common.dto
 
+import com.fasterxml.jackson.annotation.JsonProperty
+
 data class AppleAccessTokenDto(
-        val accessToken: String,
-        val tokenType: String,
-        val expiresIn: Int,
-        val refreshToken: String,
-        val idToken: String
-) {
-}
+    @JsonProperty("access_token") val accessToken: String,
+    @JsonProperty("id_token") val idToken: String,
+    @JsonProperty("token_type") val tokenType: String,
+    @JsonProperty("expires_in") val expiresIn: Int,
+    @JsonProperty("refresh_token") val refreshToken: String?
+)

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/dto/AppleUserInfoDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/dto/AppleUserInfoDto.kt
@@ -1,7 +1,10 @@
 package backend.team.ahachul_backend.common.dto
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class AppleUserInfoDto(
-    val sub: String,
-    val email: String,
-    val name: String
+    @JsonProperty("sub") val sub: String,
+    @JsonProperty("email") val email: String,
 )

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/properties/OAuthProperties.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/properties/OAuthProperties.kt
@@ -6,8 +6,9 @@ import org.springframework.context.annotation.Configuration
 @Configuration
 @ConfigurationProperties(prefix = "oauth")
 class OAuthProperties(
-        val client: Map<String, Client> = HashMap(),
-        val provider: Map<String, Provider> = HashMap()
+    val client: Map<String, Client> = HashMap(),
+    val provider: Map<String, Provider> = HashMap(),
+    val properties: Map<String, Properties> = HashMap(),
 ) {
 
     data class Client(
@@ -16,12 +17,20 @@ class OAuthProperties(
         var redirectUri: String,
         val scope: String?,
         val responseType: String,
-        val accessType: String?
+        val accessType: String?,
+        val responseMode: String?
     )
 
     data class Provider(
-            val loginUri: String,
-            val tokenUri: String,
-            val userInfoUri: String
+        val loginUri: String,
+        val tokenUri: String,
+        val userInfoUri: String?
+    )
+
+    data class Properties(
+        val kid: String?,
+        val iss: String?,
+        val sub: String?,
+        val aud: String?
     )
 }

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/properties/OAuthProperties.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/properties/OAuthProperties.kt
@@ -18,7 +18,6 @@ class OAuthProperties(
         val scope: String?,
         val responseType: String,
         val accessType: String?,
-        val responseMode: String?
     )
 
     data class Provider(

--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/properties/OAuthProperties.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/properties/OAuthProperties.kt
@@ -18,7 +18,11 @@ class OAuthProperties(
         val scope: String?,
         val responseType: String,
         val accessType: String?,
-    )
+    ) {
+        fun getRedirectUri(origin: String?): String {
+            return "${origin ?: ""}${redirectUriPath}"
+        }
+    }
 
     data class Provider(
         val loginUri: String,

--- a/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/AuthControllerDocsTest.kt
+++ b/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/AuthControllerDocsTest.kt
@@ -82,7 +82,7 @@ class AuthControllerDocsTest : CommonDocsTestConfig() {
 
         // TODO 개발용 코드. 추후 삭제
         given(oAuthProperties.client).willReturn(
-            mapOf("kakao" to OAuthProperties.Client("", "", "", "", "", "", ""))
+            mapOf("kakao" to OAuthProperties.Client("", "", "", "", "", ""))
         )
 
         val request = LoginMemberDto.Request(

--- a/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/AuthControllerDocsTest.kt
+++ b/ahachul_backend/src/test/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/AuthControllerDocsTest.kt
@@ -7,22 +7,18 @@ import backend.team.ahachul_backend.api.member.application.port.`in`.AuthUseCase
 import backend.team.ahachul_backend.api.member.domain.model.ProviderType
 import backend.team.ahachul_backend.common.properties.OAuthProperties
 import backend.team.ahachul_backend.config.controller.CommonDocsTestConfig
-import io.jsonwebtoken.lang.Maps
-import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
-import org.mockito.BDDMockito.willDoNothing
-import org.mockito.Mock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.http.MediaType
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post
-import org.springframework.restdocs.operation.preprocess.Preprocessors.*
 import org.springframework.restdocs.payload.JsonFieldType
 import org.springframework.restdocs.payload.PayloadDocumentation.*
-import org.springframework.restdocs.request.RequestDocumentation.*
+import org.springframework.restdocs.request.RequestDocumentation.parameterWithName
+import org.springframework.restdocs.request.RequestDocumentation.queryParameters
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @WebMvcTest(AuthController::class)
@@ -59,7 +55,7 @@ class AuthControllerDocsTest : CommonDocsTestConfig() {
                     getDocsRequest(),
                     getDocsResponse(),
                     queryParameters(
-                        parameterWithName("providerType").description("플랫폼 타입").attributes(getFormatAttribute("KAKAO, GOOGLE"))
+                        parameterWithName("providerType").description("플랫폼 타입").attributes(getFormatAttribute("KAKAO, GOOGLE, APPLE"))
                     ),
                     responseFields(
                         *commonResponseFields(),
@@ -86,7 +82,7 @@ class AuthControllerDocsTest : CommonDocsTestConfig() {
 
         // TODO 개발용 코드. 추후 삭제
         given(oAuthProperties.client).willReturn(
-            mapOf("kakao" to OAuthProperties.Client("", "", "", "", "", ""))
+            mapOf("kakao" to OAuthProperties.Client("", "", "", "", "", "", ""))
         )
 
         val request = LoginMemberDto.Request(
@@ -110,7 +106,7 @@ class AuthControllerDocsTest : CommonDocsTestConfig() {
                     getDocsRequest(),
                     getDocsResponse(),
                     requestFields(
-                        fieldWithPath("providerType").type("ProviderType").description("플랫폼 타입").attributes(getFormatAttribute("KAKAO, GOOGLE")),
+                        fieldWithPath("providerType").type("ProviderType").description("플랫폼 타입").attributes(getFormatAttribute("KAKAO, GOOGLE, APPLE")),
                         fieldWithPath("providerCode").type(JsonFieldType.STRING).description("인가 코드")
                     ),
                     responseFields(


### PR DESCRIPTION
## 📚 개요
+ #228 

## ✏️ 작업 내용
- [X] 애플 로그인 기능 구현
- [X] redirect url 일괄 변경 필요 `/onboarding/redirect` -> `/login/callback`

## 💡 주의 사항
+ 애플 키 파일 `.p8` 파일을 [ahachul_secret](https://github.com/ahachulTeam/ahachul_secret) repo에서 관리해도 될까요?
+ `OAuthProperties`에 애플에서 사용하는 설정정보들을 사용하기 위하여 `Properties`를 추가하였습니다.  
+ 애플에서 제공하는 사용자 정보에 `id`, `email` 뿐이라서 `isNeedAdditionalUserInfo`값이 항상 `true` 입니다.
+ ~`scope`에 대한 이슈로 `POST`로 리다이렉트를 받아야 하는 이슈~ 해결
+ ⚠️ @hwgyun 님이 작업 하신 부분이랑 동일해서 `merge` 타이밍을 잡아야 할 것 같습니다
