### PR TITLE
구글 로그인 api에서 DTO에 없는 필드를 response해도 에러가 발생하지 않도록 수정

### DIFF
--- a/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/dto/GoogleUserInfoDto.kt
+++ b/ahachul_backend/src/main/kotlin/backend/team/ahachul_backend/common/dto/GoogleUserInfoDto.kt
@@ -1,7 +1,9 @@
 package backend.team.ahachul_backend.common.dto
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class GoogleUserInfoDto(
     @JsonProperty("id") val id: String,
     @JsonProperty("email") val email: String,


### PR DESCRIPTION
#240 

## ✏️ 작업 내용
GoogleUserInfoDto에 @JsonIgnoreProperties(ignoreUnknown = true)  를 설정하여 없는 필드가 와도 에러가 발생하지 않도록 수정