### PR TITLE
✨ 첫 로그인 시 닉네임 입력 기능 동작 변경 (#250)

### DIFF
--- a/core/src/main/kotlin/backend/team/ahachul_backend/api/member/domain/entity/MemberEntity.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/api/member/domain/entity/MemberEntity.kt
@@ -49,7 +49,7 @@ class MemberEntity(
         companion object {
                 fun ofKakao(command: LoginMemberCommand, userInfo: KakaoMemberInfoDto): MemberEntity {
                         return MemberEntity(
-                                nickname = userInfo.kakaoAccount.profile?.nickname,
+                                nickname = null,
                                 providerUserId = userInfo.id,
                                 provider = command.providerType,
                                 email = userInfo.kakaoAccount.email,
@@ -61,7 +61,7 @@ class MemberEntity(
 
                 fun ofGoogle(command: LoginMemberCommand, userInfo: GoogleUserInfoDto): MemberEntity {
                         return MemberEntity(
-                                nickname = userInfo.name,
+                                nickname = null,
                                 providerUserId = userInfo.id,
                                 provider = command.providerType,
                                 email = userInfo.email,
@@ -97,7 +97,7 @@ class MemberEntity(
         }
 
         fun isNeedAdditionalUserInfo(): Boolean {
-                return nickname == null || gender == null || ageRange == null
+                return nickname == null
         }
 
         fun isConditionsMetToBlock(reportedCount: Int): Boolean {


### PR DESCRIPTION
#250 

## ✏️ 작업 내용
- isNeedAdditionalInfo 가 nickname만 체크하도록 변경
- 로그인 시 nickname을 무조건 입력받도록 변경. (기존에는 api에서 받아온 이름으로 설정)
