### PR TITLE
:recycle: 스케줄러 예외 메시지 로깅 방식 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ application/src/main/resources/static
 
 application-dev.yml
 application-local.yml
+application-test.yml

--- a/application/src/main/kotlin/backend/team/ahachul_backend/common/client/AwsS3Client.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/common/client/AwsS3Client.kt
@@ -31,7 +31,7 @@ class AwsS3Client(
                 ).withCannedAcl(CannedAccessControlList.PublicRead)
             )
         } catch (e: CommonException) {
-            logger.error(e.message, ResponseCode.BAD_REQUEST, e.stackTraceToString())
+            logger.error(e.message, ResponseCode.BAD_REQUEST, e)
         }
         return uuid
     }

--- a/application/src/test/resources/application.yml
+++ b/application/src/test/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  profiles:
+    active: test

--- a/core/src/main/kotlin/backend/team/ahachul_backend/common/logging/Logger.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/common/logging/Logger.kt
@@ -17,19 +17,19 @@ class Logger(
         logger.debug { message }
     }
 
-    fun warn(message: String?, code: ResponseCode, stackTrace: String) {
-        logger.warn { printLog(message, code, stackTrace) }
+    fun warn(message: String?, code: ResponseCode, ex: Exception) {
+        logger.warn(ex) { makeMessage(message, code) }
     }
 
     fun error(message: String?) {
         logger.error { message }
     }
 
-    fun error(message: String?, code: ResponseCode, stackTrace: String) {
-        logger.error { printLog(message, code, stackTrace) }
+    fun error(message: String?, code: ResponseCode, ex: Exception) {
+        logger.error(ex) { makeMessage(message, code) }
     }
 
-    private fun printLog(message: String?, code: ResponseCode, stackTrace: String): String {
-        return "$message - Code: ${code.code}, Message : ${code.message}, StackTrace : $stackTrace"
+    private fun makeMessage(message: String?, code: ResponseCode): String {
+        return "$message - Code: ${code.code}, Message : ${code.message}"
     }
 }

--- a/scheduler/src/main/kotlin/backend/team/ahachul_backend/schedule/job/RankHashTagJob.kt
+++ b/scheduler/src/main/kotlin/backend/team/ahachul_backend/schedule/job/RankHashTagJob.kt
@@ -4,6 +4,7 @@ import backend.team.ahachul_backend.common.client.RedisClient
 import backend.team.ahachul_backend.common.constant.CommonConstant.Companion.HASHTAG_LOG_DATETIME_FORMATTER
 import backend.team.ahachul_backend.common.constant.CommonConstant.Companion.HASHTAG_REDIS_KEY
 import backend.team.ahachul_backend.common.logging.Logger
+import backend.team.ahachul_backend.common.response.ResponseCode
 import backend.team.ahachul_backend.common.utils.LogAnalyzeUtils
 import org.quartz.JobExecutionContext
 import org.springframework.scheduling.quartz.QuartzJobBean
@@ -70,8 +71,10 @@ class RankHashTagJob(
                     pointer -= 1
                 }
             }
-        } catch (ex: FileNotFoundException) {
-            logger.error("invalid file to read : $fileUrl")
+        } catch (e: FileNotFoundException) {
+            logger.error("file not found to read : $fileUrl")
+        } catch (e: Exception) {
+            logger.error("failed to read hash tag file : $fileUrl", ResponseCode.INTERNAL_SERVER_ERROR, e.stackTraceToString())
         }
 
         return sortByTop(map)

--- a/scheduler/src/main/kotlin/backend/team/ahachul_backend/schedule/job/RankHashTagJob.kt
+++ b/scheduler/src/main/kotlin/backend/team/ahachul_backend/schedule/job/RankHashTagJob.kt
@@ -74,7 +74,7 @@ class RankHashTagJob(
         } catch (e: FileNotFoundException) {
             logger.error("file not found to read : $fileUrl")
         } catch (e: Exception) {
-            logger.error("failed to read hash tag file : $fileUrl", ResponseCode.INTERNAL_SERVER_ERROR, e.stackTraceToString())
+            logger.error("failed to read hash tag file : $fileUrl", ResponseCode.INTERNAL_SERVER_ERROR, e)
         }
 
         return sortByTop(map)

--- a/scheduler/src/main/kotlin/backend/team/ahachul_backend/schedule/job/UpdateLostDataJob.kt
+++ b/scheduler/src/main/kotlin/backend/team/ahachul_backend/schedule/job/UpdateLostDataJob.kt
@@ -86,11 +86,11 @@ class UpdateLostDataJob(
                 }
             }
         } catch (e: JsonSyntaxException) {
-            logger.error("invalid json format : $readPath")
+            logger.error("invalid json format : $readPath", ResponseCode.INTERNAL_SERVER_ERROR, e.stackTraceToString())
         } catch (e: IOException) {
-            logger.error("no data to read from file : $readPath")
+            logger.error("i/o exception occurred from file : $readPath", ResponseCode.INTERNAL_SERVER_ERROR, e.stackTraceToString())
         } catch (e: Exception) {
-            logger.error("failed to read lost112 crawling file : $readPath")
+            logger.error("failed to read lost112 crawling file : $readPath", ResponseCode.INTERNAL_SERVER_ERROR, e.stackTraceToString())
         }
     }
 

--- a/scheduler/src/main/kotlin/backend/team/ahachul_backend/schedule/job/UpdateLostDataJob.kt
+++ b/scheduler/src/main/kotlin/backend/team/ahachul_backend/schedule/job/UpdateLostDataJob.kt
@@ -86,11 +86,11 @@ class UpdateLostDataJob(
                 }
             }
         } catch (e: JsonSyntaxException) {
-            logger.error("invalid json format : $readPath", ResponseCode.INTERNAL_SERVER_ERROR, e.stackTraceToString())
+            logger.error("invalid json format : $readPath", ResponseCode.INTERNAL_SERVER_ERROR, e)
         } catch (e: IOException) {
-            logger.error("i/o exception occurred from file : $readPath", ResponseCode.INTERNAL_SERVER_ERROR, e.stackTraceToString())
+            logger.error("i/o exception occurred from file : $readPath", ResponseCode.INTERNAL_SERVER_ERROR, e)
         } catch (e: Exception) {
-            logger.error("failed to read lost112 crawling file : $readPath", ResponseCode.INTERNAL_SERVER_ERROR, e.stackTraceToString())
+            logger.error("failed to read lost112 crawling file : $readPath", ResponseCode.INTERNAL_SERVER_ERROR, e)
         }
     }
 

--- a/scheduler/src/test/resources/application.yml
+++ b/scheduler/src/test/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  profiles:
+    active: test


### PR DESCRIPTION
## 📚 개요
+ `lost112` 수집 스케줄러에서 I/O 예외가 발생했는데, 스택 트레이스를 남겨두지 않아서 cloudwatch 에서 원인 파악이 불가능해 수정해주었습니다. 에러 원인 파악을 위한 단순 로그 메시지 수정이라 별도 이슈 생성하지 않았습니다 🙃

## ✏️ 작업 내용
+ 로깅 방식 수정 -> `stacktrace` 문자열이 아니라 예외를 그대로 받아서 `logger` 에게 전달
+ `application-test.yml` 도 .gitignore에 추가

## 💡 주의 사항
+ 당장 한시에 모니터링 해봐야 해서 바로 디벨롭에 머지하겠습니다:)
