### PR TITLE
♻️ 유실물 상세조회 리팩토링 (#237)

### DIFF
--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/lost/adapter/web/in/dto/GetLostPostDto.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/lost/adapter/web/in/dto/GetLostPostDto.kt
@@ -1,7 +1,6 @@
 package backend.team.ahachul_backend.api.lost.adapter.web.`in`.dto
 
 import backend.team.ahachul_backend.api.lost.domain.entity.LostPostEntity
-import backend.team.ahachul_backend.api.lost.domain.model.LostOrigin
 import backend.team.ahachul_backend.api.lost.domain.model.LostStatus
 import backend.team.ahachul_backend.common.dto.ImageDto
 import java.time.format.DateTimeFormatter
@@ -45,7 +44,7 @@ class GetLostPostDto {
                     categoryName = entity.category?.name,
                     externalSourceImageUrl = entity.externalSourceFileUrl,
                     recommendPosts = recommendPosts,
-                    isFromLost112 = entity.origin == LostOrigin.LOST112
+                    isFromLost112 = entity.isFromLost112()
                 )
             }
         }

--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/lost/adapter/web/in/dto/GetLostPostDto.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/lost/adapter/web/in/dto/GetLostPostDto.kt
@@ -1,6 +1,7 @@
 package backend.team.ahachul_backend.api.lost.adapter.web.`in`.dto
 
 import backend.team.ahachul_backend.api.lost.domain.entity.LostPostEntity
+import backend.team.ahachul_backend.api.lost.domain.model.LostOrigin
 import backend.team.ahachul_backend.api.lost.domain.model.LostStatus
 import backend.team.ahachul_backend.common.dto.ImageDto
 import java.time.format.DateTimeFormatter
@@ -13,9 +14,9 @@ class GetLostPostDto {
         val content: String,
         val writer: String?,
         val createdBy: String?,
-        val date: String,
-        val subwayLine: Long?,
-        val chats: Int = 0,
+        val createdAt: String,
+        val subwayLineId: Long?,
+        val commentCnt: Int = 0,
         val status: LostStatus,
         val storage: String?,
         val storageNumber: String?,
@@ -23,7 +24,8 @@ class GetLostPostDto {
         val images: List<ImageDto>?,
         val categoryName: String?,
         val externalSourceImageUrl: String?,
-        val recommendPosts: List<RecommendResponse>
+        val recommendPosts: List<RecommendResponse>,
+        val isFromLost112: Boolean
     ) {
         companion object {
             fun of(entity: LostPostEntity, images: List<ImageDto>, recommendPosts: List<RecommendResponse>): Response {
@@ -33,8 +35,8 @@ class GetLostPostDto {
                     content = entity.content,
                     writer = entity.member?.nickname,
                     createdBy = entity.member?.createdBy,
-                    date = entity.date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")),
-                    subwayLine = entity.subwayLine?.id,
+                    createdAt = entity.date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")),
+                    subwayLineId = entity.subwayLine?.id,
                     status = entity.status,
                     storage = entity.storage,
                     storageNumber = entity.storageNumber,
@@ -42,7 +44,8 @@ class GetLostPostDto {
                     images = images,
                     categoryName = entity.category?.name,
                     externalSourceImageUrl = entity.externalSourceFileUrl,
-                    recommendPosts = recommendPosts
+                    recommendPosts = recommendPosts,
+                    isFromLost112 = entity.origin == LostOrigin.LOST112
                 )
             }
         }
@@ -53,6 +56,6 @@ class GetLostPostDto {
         val title: String,
         val writer: String,
         val imageUrl: String?,
-        val date: String
+        val createdAt: String
     )
 }

--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/lost/application/service/LostPostService.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/lost/application/service/LostPostService.kt
@@ -82,7 +82,7 @@ class LostPostService(
                 title = post.title,
                 writer = post.createdBy,
                 imageUrl = getFileSource(post),
-                date = post.date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")),
+                createdAt = post.date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")),
             )
         }
         return recommendPostsDto

--- a/application/src/test/kotlin/backend/team/ahachul_backend/api/lost/adapter/web/in/LostPostControllerDocsTest.kt
+++ b/application/src/test/kotlin/backend/team/ahachul_backend/api/lost/adapter/web/in/LostPostControllerDocsTest.kt
@@ -36,7 +36,7 @@ class LostPostControllerDocsTest: CommonDocsTestConfig() {
             id = 2,
             title = "title",
             writer = "writer",
-            date = "2023/01/23",
+            createdAt = "2023/01/23",
             imageUrl = "https://img.png"
         )
 
@@ -46,9 +46,9 @@ class LostPostControllerDocsTest: CommonDocsTestConfig() {
             content = "content",
             writer = "writer",
             createdBy = "1",
-            date = "2023/01/23",
-            subwayLine = 1,
-            chats = 1,
+            createdAt = "2023/01/23",
+            subwayLineId = 1,
+            commentCnt = 1,
             status = LostStatus.PROGRESS,
             storage = "우리집",
             storageNumber = "02-2222-3333",
@@ -56,7 +56,8 @@ class LostPostControllerDocsTest: CommonDocsTestConfig() {
             images = listOf(ImageDto(1, "https://img.png")),
             categoryName = "휴대폰",
             externalSourceImageUrl = "http://lost112/image.png",
-            recommendPosts = listOf(recommendPost)
+            recommendPosts = listOf(recommendPost),
+            isFromLost112 = true,
         )
 
         given(lostPostUseCase.getLostPost(anyLong()))
@@ -83,9 +84,10 @@ class LostPostControllerDocsTest: CommonDocsTestConfig() {
                     fieldWithPath("result.content").type(JsonFieldType.STRING).description("유실물 내용"),
                     fieldWithPath("result.writer").type(JsonFieldType.STRING).description("유실물 작성자 닉네임"),
                     fieldWithPath("result.createdBy").type(JsonFieldType.STRING).description("작성자 ID"),
-                    fieldWithPath("result.date").type(JsonFieldType.STRING).description("유실물 작성 날짜"),
-                    fieldWithPath("result.subwayLine").type(JsonFieldType.NUMBER).description("유실 호선"),
-                    fieldWithPath("result.chats").type(JsonFieldType.NUMBER).description("유실물 쪽지 개수"),
+                    fieldWithPath("result.createdAt").type(JsonFieldType.STRING).description("유실물 작성 날짜"),
+                    fieldWithPath("result.subwayLineId").type(JsonFieldType.NUMBER).description("유실 호선"),
+                    fieldWithPath("result.commentCnt").type(JsonFieldType.NUMBER).description("유실물 쪽지 개수"),
+                    fieldWithPath("result.isFromLost112").type(JsonFieldType.BOOLEAN).description("Lost112 여부"),
                     fieldWithPath("result.status").type(JsonFieldType.STRING).description("유실물 찾기 완료 여부").attributes(getFormatAttribute( "PROGRESS / COMPLETE")),
                     fieldWithPath("result.storage" ).type(JsonFieldType.STRING).description("보관 장소").attributes(getFormatAttribute("Lost112 데이터")),
                     fieldWithPath("result.storageNumber").type(JsonFieldType.STRING).description("보관 장소 전화번호").attributes(getFormatAttribute("Lost112 데이터")),
@@ -98,7 +100,7 @@ class LostPostControllerDocsTest: CommonDocsTestConfig() {
                     fieldWithPath("result.recommendPosts[].id").type(JsonFieldType.NUMBER).description("추천 유실물 아이디"),
                     fieldWithPath("result.recommendPosts[].title").type(JsonFieldType.STRING).description("추천 유실물 제목"),
                     fieldWithPath("result.recommendPosts[].writer").type(JsonFieldType.STRING).description("추천 유실물 작성자"),
-                    fieldWithPath("result.recommendPosts[].date").type(JsonFieldType.STRING).description("추천 유실물 생성 일자"),
+                    fieldWithPath("result.recommendPosts[].createdAt").type(JsonFieldType.STRING).description("추천 유실물 생성 일자"),
                     fieldWithPath("result.recommendPosts[].imageUrl").type(JsonFieldType.STRING).description("추천 유실물 썸네일 경로"),
                 )
             ))

--- a/application/src/test/kotlin/backend/team/ahachul_backend/api/lost/application/service/LostPostServiceTest.kt
+++ b/application/src/test/kotlin/backend/team/ahachul_backend/api/lost/application/service/LostPostServiceTest.kt
@@ -74,7 +74,7 @@ class LostPostServiceTest(
         assertThat(response.title).isEqualTo("지갑 주인 찾아요")
         assertThat(response.content).isEqualTo("내용")
         assertThat(response.writer).isEqualTo("nickname")
-        assertThat(response.subwayLine).isEqualTo(subwayLine.id)
+        assertThat(response.subwayLineId).isEqualTo(subwayLine.id)
         assertThat(response.status).isEqualTo(LostStatus.PROGRESS)
     }
 

--- a/core/src/main/kotlin/backend/team/ahachul_backend/api/lost/domain/entity/LostPostEntity.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/api/lost/domain/entity/LostPostEntity.kt
@@ -121,6 +121,10 @@ class LostPostEntity(
         return lostPostReports.size >= MIN_BLOCK_REPORT_COUNT
     }
 
+    fun isFromLost112(): Boolean {
+        return origin == LostOrigin.LOST112
+    }
+
     fun block() {
         type = LostPostType.BLOCKED
     }


### PR DESCRIPTION
## 📚 개요
+ #237 

## ✏️ 작업 내용
+ `date` 필드 `createdAt` 네이밍 변경
+ `subwayLine` 필드 `subwayLineId` 네이밍 변경
+ `chats` 필드 `commentCnt` 네이밍 변경
+ `isFromLost112` 필드 추가

## 💡 주의 사항
+ `GetLostPostDto`에 `isFromLost112`를 추가했는데 다음과 같이 작성해도 되는지 궁금합니다 🙃
```java
isFromLost112 = entity.origin == LostOrigin.LOST112
```
