### PR TITLE
🐛 애플 로그인 시, p8 키 파일 못찾는 에러 수정 (#261)

### DIFF
--- a/application/src/main/kotlin/backend/team/ahachul_backend/common/client/impl/AppleMemberClientImpl.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/common/client/impl/AppleMemberClientImpl.kt
@@ -15,8 +15,6 @@ import org.springframework.http.*
 import org.springframework.stereotype.Component
 import org.springframework.util.LinkedMultiValueMap
 import org.springframework.web.client.RestTemplate
-import java.nio.file.Files
-import java.nio.file.Path
 import java.security.KeyFactory
 import java.security.PrivateKey
 import java.security.spec.KeySpec
@@ -100,10 +98,6 @@ class AppleMemberClientImpl(
     }
 
     private fun getKeyBytes(): ByteArray {
-        return Files.readAllBytes(getKeyFilePath())
-    }
-
-    private fun getKeyFilePath(): Path {
-        return ClassPathResource(properties.kid + ".p8").file.toPath()
+        return ClassPathResource(properties.kid + ".p8").inputStream.readAllBytes()
     }
 }


### PR DESCRIPTION
## 📚 개요
+ #261 

## ✏️ 작업 내용
+ jar 배포 시, p8파일을 못찾는 에러가 있어 `ClassPathResource.file`에서 `ClassPathResource.inputStream`으로 변경 

## 💡 주의 사항
+ 로컬에서는 정상 작동 되나, 개발서버 배포 시에 발생하는 에러로 해당 PR 배포된 이후 확인해봐야 될 것 같아요!! 😁
