### PR TITLE
:bug: SNS 로그인 시, 회원테이블 INSERT 오류 발생 수정 (#266)

### DIFF
--- a/core/src/main/resources/db/migration/V202411181200__update_member_nickname_null.sql
+++ b/core/src/main/resources/db/migration/V202411181200__update_member_nickname_null.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tb_member
+    MODIFY COLUMN nickname VARCHAR(100) NULL;


### PR DESCRIPTION
## 📚 개요
+ #266 

## ✏️ 작업 내용
+ `member` 테이블의 `nickname` 컬럼 `null` 허용 스크립트 추가