### PR TITLE
:recycle: 스케줄러 서버로 검색 로그 전송 (#254)

### DIFF
--- a/.github/workflows/dev-api-deploy.yml
+++ b/.github/workflows/dev-api-deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - feature/254
     paths-ignore:
       - 'scheduler/**'
       - '.github/**'

--- a/.github/workflows/dev-api-deploy.yml
+++ b/.github/workflows/dev-api-deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - develop
-      - feature/254
     paths-ignore:
       - 'scheduler/**'
       - '.github/**'

--- a/.github/workflows/dev-batch-deploy.yml
+++ b/.github/workflows/dev-batch-deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - feature/254
     paths-ignore:
       - 'application/**'
       - '.github/**'

--- a/.github/workflows/dev-batch-deploy.yml
+++ b/.github/workflows/dev-batch-deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - develop
-      - feature/254
     paths-ignore:
       - 'application/**'
       - '.github/**'

--- a/application/src/main/resources/logback-spring.xml
+++ b/application/src/main/resources/logback-spring.xml
@@ -91,15 +91,16 @@
     <appender name="HASHTAG_SOCKET" class="ch.qos.logback.classic.net.SocketAppender">
         <remoteHost>${HASHTAG_LOG_HOST_NAME}</remoteHost>
         <port>${HASHTAG_LOG_PORT}</port>
+<!--        <includeCallerData>true</includeCallerData>-->
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <pattern>${HASHTAG_LOG_PATTERN}</pattern>
         </encoder>
     </appender>
 
     <appender name="HASHTAG_ASYNC_SOCKET" class="ch.qos.logback.classic.AsyncAppender">
-        <queueSize>512</queueSize> <!-- 로그 버퍼 크기 -->
-        <discardingThreshold>0</discardingThreshold> <!-- 큐가 가득 찼을 때 버릴 로그 수준 설정 -->
-        <neverBlock>true</neverBlock> <!-- 큐가 가득 차도 메인 스레드가 차단되지 않도록 설정 -->
+        <queueSize>512</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+        <neverBlock>true</neverBlock>
         <appender-ref ref="HASHTAG_SOCKET"/>
     </appender>
 

--- a/application/src/main/resources/logback-spring.xml
+++ b/application/src/main/resources/logback-spring.xml
@@ -19,7 +19,7 @@
         <property name="HASHTAG_LOG_HOST_NAME" value="${log.config.hashtag.hostname}"/>
     </springProfile>
 
-    <springProfile name="local">
+    <springProfile name="local, test">
         <property name="HASHTAG_LOG_HOST_NAME" value="${log.config.hashtag.hostname.local}"/>
     </springProfile>
 
@@ -91,7 +91,6 @@
     <appender name="HASHTAG_SOCKET" class="ch.qos.logback.classic.net.SocketAppender">
         <remoteHost>${HASHTAG_LOG_HOST_NAME}</remoteHost>
         <port>${HASHTAG_LOG_PORT}</port>
-<!--        <includeCallerData>true</includeCallerData>-->
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <pattern>${HASHTAG_LOG_PATTERN}</pattern>
         </encoder>

--- a/application/src/main/resources/logback-spring.xml
+++ b/application/src/main/resources/logback-spring.xml
@@ -72,22 +72,6 @@
         </filter>
     </appender>
 
-    <appender name="HASHTAG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${HASHTAG_LOG_PATH}/${HASHTAG_LOG_FILE_NAME}.log</file>
-
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>${HASHTAG_LOG_PATTERN}</pattern>
-        </encoder>
-
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${HASHTAG_LOG_PATH}/${HASHTAG_LOG_FILE_NAME}.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
-                <maxFileSize>10MB</maxFileSize>
-            </timeBasedFileNamingAndTriggeringPolicy>
-            <maxHistory>30</maxHistory>
-        </rollingPolicy>
-    </appender>
-
     <appender name="HASHTAG_SOCKET" class="ch.qos.logback.classic.net.SocketAppender">
         <remoteHost>${HASHTAG_LOG_HOST_NAME}</remoteHost>
         <port>${HASHTAG_LOG_PORT}</port>
@@ -110,7 +94,7 @@
     </root>
 
     <logger name="HASHTAG_LOGGER" LEVEL="INFO">
-        <appender-ref ref="HASHTAG_SOCKET"/>
+        <appender-ref ref="HASHTAG_ASYNC_SOCKET"/>
     </logger>
 
 </configuration>

--- a/application/src/main/resources/logback-spring.xml
+++ b/application/src/main/resources/logback-spring.xml
@@ -110,7 +110,7 @@
     </root>
 
     <logger name="HASHTAG_LOGGER" LEVEL="INFO">
-        <appender-ref ref="HASHTAG_ASYNC_SOCKET"/>
+        <appender-ref ref="HASHTAG_SOCKET"/>
     </logger>
 
 </configuration>

--- a/application/src/main/resources/logback-spring.xml
+++ b/application/src/main/resources/logback-spring.xml
@@ -14,6 +14,8 @@
 
     <property name="HASHTAG_LOG_PATH" value="${log.config.hashtag.path}"/>
     <property name="HASHTAG_LOG_FILE_NAME" value="${log.config.hashtag.filename}"/>
+    <property name="HASHTAG_LOG_HOST_NAME" value="${log.config.hashtag.hostname}"/>
+    <property name="HASHTAG_LOG_PORT" value="${log.config.hashtag.port}"/>
 
     <property name="LOG_PATTERN" value="%-5level %d{yy-MM-dd HH:mm:ss}[%thread] [%logger{0}:%line] - %msg%n"/>
     <property name="HASHTAG_LOG_PATTERN" value="%d{yy-MM-dd HH:mm:ss} [%logger{0}:%line] %msg%n"/>
@@ -76,7 +78,21 @@
             </timeBasedFileNamingAndTriggeringPolicy>
             <maxHistory>30</maxHistory>
         </rollingPolicy>
+    </appender>
 
+    <appender name="HASHTAG_SOCKET" class="ch.qos.logback.classic.net.SocketAppender">
+        <remoteHost>${HASHTAG_LOG_HOST_NAME}</remoteHost>
+        <port>${HASHTAG_LOG_PORT}</port>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>${HASHTAG_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="HASHTAG_ASYNC_SOCKET" class="ch.qos.logback.classic.AsyncAppender">
+        <queueSize>512</queueSize> <!-- 로그 버퍼 크기 -->
+        <discardingThreshold>0</discardingThreshold> <!-- 큐가 가득 찼을 때 버릴 로그 수준 설정 -->
+        <neverBlock>true</neverBlock> <!-- 큐가 가득 차도 메인 스레드가 차단되지 않도록 설정 -->
+        <appender-ref ref="HASHTAG_SOCKET"/>
     </appender>
 
     <root level="{LOG_LEVEL}">
@@ -86,7 +102,7 @@
     </root>
 
     <logger name="HASHTAG_LOGGER" LEVEL="INFO">
-        <appender-ref ref="HASHTAG_FILE"/>
+        <appender-ref ref="HASHTAG_ASYNC_SOCKET"/>
     </logger>
 
 </configuration>

--- a/application/src/main/resources/logback-spring.xml
+++ b/application/src/main/resources/logback-spring.xml
@@ -14,7 +14,15 @@
 
     <property name="HASHTAG_LOG_PATH" value="${log.config.hashtag.path}"/>
     <property name="HASHTAG_LOG_FILE_NAME" value="${log.config.hashtag.filename}"/>
-    <property name="HASHTAG_LOG_HOST_NAME" value="${log.config.hashtag.hostname}"/>
+
+    <springProfile name="dev">
+        <property name="HASHTAG_LOG_HOST_NAME" value="${log.config.hashtag.hostname}"/>
+    </springProfile>
+
+    <springProfile name="local">
+        <property name="HASHTAG_LOG_HOST_NAME" value="${log.config.hashtag.hostname.local}"/>
+    </springProfile>
+
     <property name="HASHTAG_LOG_PORT" value="${log.config.hashtag.port}"/>
 
     <property name="LOG_PATTERN" value="%-5level %d{yy-MM-dd HH:mm:ss}[%thread] [%logger{0}:%line] - %msg%n"/>

--- a/core/src/main/resources/logback.properties
+++ b/core/src/main/resources/logback.properties
@@ -6,8 +6,8 @@ log.config.error.path=./error_logs
 log.config.error.filename=error_log
 log.config.error.archive.path=./error_logs/archive
 
-log.config.hashtag.path=./logs/archive/hashtag
+log.config.hashtag.path=./scheduler/logs/archive/hashtag
 log.config.hashtag.filename=hashtag_log
 log.config.hashtag.hostname=internal.scheduler
 log.config.hashtag.hostname.local=localhost
-log.config.hashtag.port=8080
+log.config.hashtag.port=5001

--- a/core/src/main/resources/logback.properties
+++ b/core/src/main/resources/logback.properties
@@ -8,3 +8,5 @@ log.config.error.archive.path=./error_logs/archive
 
 log.config.hashtag.path=./logs/archive/hashtag
 log.config.hashtag.filename=hashtag_log
+log.config.hashtag.hostname=ip-10-0-3-100.ap-northeast-2.compute.internal
+log.config.hashtag.port=8080

--- a/core/src/main/resources/logback.properties
+++ b/core/src/main/resources/logback.properties
@@ -8,5 +8,5 @@ log.config.error.archive.path=./error_logs/archive
 
 log.config.hashtag.path=./logs/archive/hashtag
 log.config.hashtag.filename=hashtag_log
-log.config.hashtag.hostname=ip-10-0-3-100.ap-northeast-2.compute.internal
+log.config.hashtag.hostname=internal.scheduler
 log.config.hashtag.port=8080

--- a/core/src/main/resources/logback.properties
+++ b/core/src/main/resources/logback.properties
@@ -9,4 +9,5 @@ log.config.error.archive.path=./error_logs/archive
 log.config.hashtag.path=./logs/archive/hashtag
 log.config.hashtag.filename=hashtag_log
 log.config.hashtag.hostname=internal.scheduler
+log.config.hashtag.hostname.local=localhost
 log.config.hashtag.port=8080

--- a/scheduler/src/main/kotlin/backend/team/ahachul_backend/ScheduleModuleApplication.kt
+++ b/scheduler/src/main/kotlin/backend/team/ahachul_backend/ScheduleModuleApplication.kt
@@ -1,11 +1,18 @@
 package backend.team.ahachul_backend
 
+import backend.team.ahachul_backend.common.properties.SocketServerProperties
+import ch.qos.logback.classic.net.SimpleSocketServer
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.runApplication
+import org.springframework.context.ApplicationContext
 
 @SpringBootApplication
+@EnableConfigurationProperties
 class ScheduleModuleApplication
 
 fun main(args: Array<String>) {
-    runApplication<ScheduleModuleApplication>(*args)
+    val context: ApplicationContext = runApplication<ScheduleModuleApplication>(*args)
+    val properties = context.getBean(SocketServerProperties::class.java)
+    SimpleSocketServer.main(arrayOf(properties.port, properties.configPath))
 }

--- a/scheduler/src/main/kotlin/backend/team/ahachul_backend/common/properties/SocketServerProperties.kt
+++ b/scheduler/src/main/kotlin/backend/team/ahachul_backend/common/properties/SocketServerProperties.kt
@@ -1,0 +1,11 @@
+package backend.team.ahachul_backend.common.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ConfigurationProperties(prefix = "socket-server")
+data class SocketServerProperties(
+    var port: String = "",
+    var configPath: String = ""
+)

--- a/scheduler/src/main/resources/logback-spring.xml
+++ b/scheduler/src/main/resources/logback-spring.xml
@@ -1,0 +1,85 @@
+<configuration scan="true" scanPeriod="60 seconds">
+
+    <property resource="logback.properties"/>
+
+    <springProperty scope="context" name="LOG_LEVEL" source="logging.level.root"/>
+
+    <property name="LOG_PATH" value="${log.config.path}"/>
+    <property name="LOG_FILE_NAME" value="${log.config.filename}"/>
+    <property name="LOG_ARCHIVE_PATH" value="${log.config.archive.path}"/>
+
+    <property name="ERROR_LOG_PATH" value="${log.config.error.path}"/>
+    <property name="ERROR_LOG_FILE_NAME" value="${log.config.error.filename}"/>
+    <property name="ERROR_LOG_ARCHIVE_PATH" value="${log.config.error.archive.path}"/>
+
+    <property name="HASHTAG_LOG_PATH" value="${log.config.hashtag.path}"/>
+    <property name="HASHTAG_LOG_FILE_NAME" value="${log.config.hashtag.filename}"/>
+
+    <property name="LOG_PATTERN" value="%-5level %d{yy-MM-dd HH:mm:ss}[%thread] [%logger{0}:%line] - %msg%n"/>
+    <property name="HASHTAG_LOG_PATTERN" value="%d{yy-MM-dd HH:mm:ss} [%logger{0}:%line] %msg%n"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/${LOG_FILE_NAME}.log</file>
+
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_ARCHIVE_PATH}/${LOG_FILE_NAME}.%d{yyyy-MM-dd}_%i.log</fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>10MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+    </appender>
+
+    <appender name="ERROR_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${ERROR_LOG_PATH}/${ERROR_LOG_FILE_NAME}.log</file>
+
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${ERROR_LOG_ARCHIVE_PATH}/${ERROR_LOG_FILE_NAME}.%d{yyyy-MM-dd}_%i.log</fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>10MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <maxHistory>60</maxHistory>
+        </rollingPolicy>
+
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>error</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+    </appender>
+
+    <appender name="HASHTAG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${HASHTAG_LOG_PATH}/${HASHTAG_LOG_FILE_NAME}.log</file>
+
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>${HASHTAG_LOG_PATTERN}</pattern>
+        </encoder>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${HASHTAG_LOG_PATH}/${HASHTAG_LOG_FILE_NAME}.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>10MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+    </appender>
+
+    <logger name="HASHTAG_LOGGER" LEVEL="INFO">
+        <appender-ref ref="HASHTAG_FILE"/>
+    </logger>
+
+</configuration>

--- a/scheduler/src/main/resources/logback-spring.xml
+++ b/scheduler/src/main/resources/logback-spring.xml
@@ -78,6 +78,12 @@
         </rollingPolicy>
     </appender>
 
+    <root level="{LOG_LEVEL}">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="FILE"/>
+        <appender-ref ref="ERROR_FILE"/>
+    </root>
+
     <logger name="HASHTAG_LOGGER" LEVEL="INFO">
         <appender-ref ref="HASHTAG_FILE"/>
     </logger>


### PR DESCRIPTION
## 📚 개요
+ #254 

## ✏️ 작업 내용
> 해시태그 검색 로그를 바탕으로 해시태그 랭킹이 집계가 되고 있는 상황

+ 서버 분리에 따라 비동기로 `api-server` 에서 검색 로그를 `batch-server로`  전송하도록 수정했습니다.

### Jmeter 테스트 결과

1. 동시 접속 10명 대상
- 동기 방식 : 중앙값 215ms
<img width="952" alt="스크린샷 2024-12-02 오후 4 19 27" src="https://github.com/user-attachments/assets/d7671bb8-9372-496d-bab7-9c6d9e586696">

- 비동기 방식 : 중앙값 115ms
<img width="948" alt="image" src="https://github.com/user-attachments/assets/7132d4b2-6f43-4a31-be0a-1efafddbb1ba">

2. 동시 접속 1000명 대상
- 동기 방식 : 중앙값 7205ms
<img width="1025" alt="image" src="https://github.com/user-attachments/assets/a3ee5a6f-fb33-441c-a3c9-5dd6d04e7190">

- 비동기 방식 : 중앙값 6212ms
<img width="1027" alt="image" src="https://github.com/user-attachments/assets/e1ee6ef4-153f-4848-90aa-b3461506277a">
엄청 느려진거 보면 다른 쪽에서 병목이 발생하는 것 같네요?


## 💡 주의 사항
+ 성능 테스트
   +  TCP 연결 수립(SocketAppender) 때문에 비동기 방식이 성능이 확실히 좋을 것 같았는데 생각보다 큰 차이가 없네요 😥

+ 선택 이유
    + 로그를 받는 SimpleSocketServer가 blocking 방식이라 netty를 사용하려고 했는데 역직렬화에서 문제가 생겨서 기본 제공SimpleSocketServer를 선택했습니다.

+ 추후 개선 포인트
  + 배치 서버에 있는 로그 파일 S3에 주기적으로 백업 필요
  + community쪽 search 성능 최적화(이전에 유실물만 개선했던 거라 한번 확인해보겠습니다)