### PR TITLE
:bug: 유실물 작성자 필드가 제대로 오지 않는 현상 해결 (#289)

### DIFF
--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/lost/adapter/web/in/dto/GetLostPostDto.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/lost/adapter/web/in/dto/GetLostPostDto.kt
@@ -33,7 +33,7 @@ class GetLostPostDto {
                     title = entity.title,
                     content = entity.content,
                     writer = entity.member?.nickname,
-                    createdBy = entity.member?.createdBy,
+                    createdBy = entity.createdBy,
                     createdAt = entity.date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")),
                     subwayLineId = entity.subwayLine?.id,
                     status = entity.status,

--- a/application/src/main/kotlin/backend/team/ahachul_backend/common/interceptor/AuthenticationInterceptor.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/common/interceptor/AuthenticationInterceptor.kt
@@ -44,16 +44,16 @@ class AuthenticationInterceptor(
             }
             when (e) {
                 is SignatureException, is UnsupportedJwtException, is IllegalArgumentException, is MalformedJwtException -> {
-                    throw CommonException(ResponseCode.INVALID_ACCESS_TOKEN)
+                    throw CommonException(ResponseCode.INVALID_ACCESS_TOKEN, e)
                 }
 
                 is ExpiredJwtException -> {
-                    throw CommonException(ResponseCode.EXPIRED_ACCESS_TOKEN)
+                    throw CommonException(ResponseCode.EXPIRED_ACCESS_TOKEN, e)
                 }
 
                 else -> {
                     if (e.message == ResponseCode.BLOCKED_MEMBER.message) throw e
-                    throw CommonException(ResponseCode.INTERNAL_SERVER_ERROR)
+                    throw CommonException(ResponseCode.INTERNAL_SERVER_ERROR, e)
                 }
             }
         }


### PR DESCRIPTION
## 📚 개요
+ #289  

## ✏️ 작업 내용
+ 로그인 된 유저가 있을 경우 자동으로 createdBy를 해당 작성자의 ID값으로 저장되도록 해놨었는데, 막상 보여줄때 다른 createdBy 필드를 가지고 반환하고 있어서 수정해주었습니다.

## 💡 주의 사항
+ 관련 코드는 common > JpaConfig에 있습니다:)
```kotlin
    @Bean
    fun auditorProvider() = AuditorAware {
        val memberId: String = RequestUtils.getAttribute(MEMBER_ID) ?: UNAUTHORIZED_VALUE
        Optional.of(memberId)
    }
```
