### PR TITLE
:bug: 유실물 업데이트 REST DOCS 매핑 오류 수정 (#301)

### DIFF
--- a/application/src/docs/asciidoc/lost/posts.adoc
+++ b/application/src/docs/asciidoc/lost/posts.adoc
@@ -44,9 +44,9 @@ include::{snippets}/update-lost-post/http-request.adoc[]
 .Request Headers
 include::{snippets}/update-lost-post/request-headers.adoc[]
 .Request Parts
-include::{snippets}/create-lost-post/request-parts.adoc[]
+include::{snippets}/update-lost-post/request-parts.adoc[]
 .Request Parts - content
-include::{snippets}/create-lost-post/request-part-content-fields.adoc[]
+include::{snippets}/update-lost-post/request-part-content-fields.adoc[]
 .Response
 include::{snippets}/update-lost-post/http-response.adoc[]
 .Response Fields

--- a/application/src/test/kotlin/backend/team/ahachul_backend/api/lost/adapter/web/in/LostPostControllerDocsTest.kt
+++ b/application/src/test/kotlin/backend/team/ahachul_backend/api/lost/adapter/web/in/LostPostControllerDocsTest.kt
@@ -316,7 +316,7 @@ class LostPostControllerDocsTest: CommonDocsTestConfig() {
                     fieldWithPath("subwayLineId").type(JsonFieldType.NUMBER).description("유실 호선 ID").optional(),
                     fieldWithPath("status").type(JsonFieldType.STRING).description("유실물 찾기 완료 상태")
                         .attributes(getFormatAttribute( "PROGRESS / COMPLETE")).optional(),
-                    fieldWithPath("removeFileIds").type(JsonFieldType.ARRAY).description("삭제할 유실물 이미지 번호 리스트"),
+                    fieldWithPath("removeFileIds").type(JsonFieldType.ARRAY).description("삭제할 유실물 이미지 번호 리스트").optional(),
                     fieldWithPath("categoryName").type(JsonFieldType.STRING).description("[deprecated] 카테고리 이름").optional() // deprecated
                 ),
                 responseFields(


### PR DESCRIPTION
## 📚 개요
+ #301 

## ✏️ 작업 내용
+ 유실물 수정 REST Docs 수정

## 💡 주의 사항
+ 커밋 메세지의 이슈번호 참조가 잘못되었네요 😂
