### PR TITLE
🐛 로컬 테스트 시 유실물 게시글 작성이 안되는 현상 (#309)

### DIFF
--- a/core/src/main/kotlin/backend/team/ahachul_backend/api/community/domain/entity/CommunityPostEntity.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/api/community/domain/entity/CommunityPostEntity.kt
@@ -23,6 +23,7 @@ class CommunityPostEntity(
     var title: String,
 
     @Lob
+    @Column(columnDefinition = "text")
     var content: String,
 
     @Enumerated(EnumType.STRING)

--- a/core/src/main/kotlin/backend/team/ahachul_backend/api/community/domain/entity/CommunityPostEntity.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/api/community/domain/entity/CommunityPostEntity.kt
@@ -22,6 +22,7 @@ class CommunityPostEntity(
 
     var title: String,
 
+    @Lob
     var content: String,
 
     @Enumerated(EnumType.STRING)

--- a/core/src/main/kotlin/backend/team/ahachul_backend/api/community/domain/entity/CommunityPostEntity.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/api/community/domain/entity/CommunityPostEntity.kt
@@ -22,7 +22,6 @@ class CommunityPostEntity(
 
     var title: String,
 
-    @Lob
     @Column(columnDefinition = "text")
     var content: String,
 

--- a/core/src/main/kotlin/backend/team/ahachul_backend/api/lost/domain/entity/LostPostEntity.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/api/lost/domain/entity/LostPostEntity.kt
@@ -40,7 +40,6 @@ class LostPostEntity(
 
     var title: String,
 
-    @Lob
     @Column(columnDefinition = "text")
     var content: String,
 

--- a/core/src/main/kotlin/backend/team/ahachul_backend/api/lost/domain/entity/LostPostEntity.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/api/lost/domain/entity/LostPostEntity.kt
@@ -41,6 +41,7 @@ class LostPostEntity(
     var title: String,
 
     @Lob
+    @Column(columnDefinition = "text")
     var content: String,
 
     @Enumerated(value = EnumType.STRING)

--- a/core/src/main/kotlin/backend/team/ahachul_backend/api/lost/domain/entity/LostPostEntity.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/api/lost/domain/entity/LostPostEntity.kt
@@ -40,6 +40,7 @@ class LostPostEntity(
 
     var title: String,
 
+    @Lob
     var content: String,
 
     @Enumerated(value = EnumType.STRING)


### PR DESCRIPTION
## 📚 개요
#309 

## ✏️ 작업 내용
+ JPA @Lob 어노테이션과 postgresql text 타입 필드 불일치로 인한 버그 수정
