### PR TITLE
✨ 로그아웃 구현 (#313)

### DIFF
--- a/application/src/docs/asciidoc/member/oauth.adoc
+++ b/application/src/docs/asciidoc/member/oauth.adoc
@@ -22,6 +22,17 @@ include::{snippets}/login/http-response.adoc[]
 .Response Fields
 include::{snippets}/login/response-fields.adoc[]
 
+==== 로그아웃
+
+.Request
+include::{snippets}/logout/http-request.adoc[]
+.Request Fields
+include::{snippets}/logout/request-fields.adoc[]
+.Response
+include::{snippets}/logout/http-response.adoc[]
+.Response Fields
+include::{snippets}/logout/response-fields.adoc[]
+
 ==== 토큰 재발급
 
 - 리프레쉬 토큰 만료 기간이 7일보다 적게 남았을 경우 리프레쉬 토큰 또한 재발급

--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/AuthController.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/AuthController.kt
@@ -3,6 +3,7 @@ package backend.team.ahachul_backend.api.member.adapter.web.`in`
 import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.GetRedirectUrlDto
 import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.GetTokenDto
 import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.LoginMemberDto
+import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.LogoutMemberDto
 import backend.team.ahachul_backend.api.member.application.port.`in`.AuthUseCase
 import backend.team.ahachul_backend.api.member.application.port.`in`.command.GetRedirectUrlCommand
 import backend.team.ahachul_backend.api.member.domain.model.ProviderType
@@ -28,6 +29,12 @@ class AuthController(
     @PostMapping("/v1/auth/login")
     fun login(@RequestHeader(value = "Origin") origin: String?, @RequestBody request: LoginMemberDto.Request): CommonResponse<LoginMemberDto.Response> {
         return CommonResponse.success(authUseCase.login(request.toCommand(origin)))
+    }
+
+    @PostMapping("/v1/auth/logout")
+    fun logout(@RequestBody request: LogoutMemberDto.Request): CommonResponse<*> {
+        authUseCase.logout(request.accessToken)
+        return CommonResponse.success()
     }
 
     @PostMapping("/v1/auth/token/refresh")

--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/dto/LogoutMemberDto.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/dto/LogoutMemberDto.kt
@@ -1,0 +1,10 @@
+package backend.team.ahachul_backend.api.member.adapter.web.`in`.dto
+
+class LogoutMemberDto {
+
+    data class Request(
+        val accessToken: String,
+    ) {
+
+    }
+}

--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/in/AuthUseCase.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/in/AuthUseCase.kt
@@ -11,6 +11,8 @@ interface AuthUseCase {
 
     fun login(command: LoginMemberCommand): LoginMemberDto.Response
 
+    fun logout(accessToken: String)
+
     fun getToken(command: GetTokenCommand): GetTokenDto.Response
 
     fun getRedirectUrl(command: GetRedirectUrlCommand): GetRedirectUrlDto.Response

--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/member/application/service/AuthLogoutCacheUtils.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/member/application/service/AuthLogoutCacheUtils.kt
@@ -1,0 +1,51 @@
+package backend.team.ahachul_backend.api.member.application.service
+
+import backend.team.ahachul_backend.common.client.RedisClient
+import backend.team.ahachul_backend.common.exception.CommonException
+import backend.team.ahachul_backend.common.properties.JwtProperties
+import backend.team.ahachul_backend.common.response.ResponseCode
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.concurrent.TimeUnit
+
+@Component
+class AuthLogoutCacheUtils(
+    private val redisClient: RedisClient,
+    private val jwtProperties: JwtProperties,
+) {
+
+    fun logout(accessToken: String) {
+        alreadyLogout(accessToken)
+
+        val key = createKey(accessToken)
+        val value = now()
+
+        redisClient.set(key, value, jwtProperties.accessTokenExpireTime, TimeUnit.SECONDS)
+    }
+
+    fun alreadyLogout(accessToken: String) {
+        if (isLogout(accessToken)) {
+            throw CommonException(ResponseCode.ALREADY_LOGOUT_TOKEN)
+        }
+    }
+
+    fun isNotLogout(accessToken: String): Boolean {
+        val key = createKey(accessToken)
+        return redisClient.get(key).isNullOrEmpty()
+    }
+
+    private fun isLogout(accessToken: String) = !isNotLogout(accessToken)
+
+    private fun createKey(accessToken: String): String {
+        return "${LOGOUT_BLACKLIST_REDIS_PREFIX}${accessToken}"
+    }
+
+    private fun now(): String {
+        return LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS"))
+    }
+
+    companion object {
+        const val LOGOUT_BLACKLIST_REDIS_PREFIX = "LOGOUT_BLACKLIST:"
+    }
+}

--- a/application/src/test/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/AuthControllerDocsTest.kt
+++ b/application/src/test/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/AuthControllerDocsTest.kt
@@ -3,12 +3,15 @@ package backend.team.ahachul_backend.api.member.adapter.web.`in`
 import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.GetRedirectUrlDto
 import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.GetTokenDto
 import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.LoginMemberDto
+import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.LogoutMemberDto
 import backend.team.ahachul_backend.api.member.application.port.`in`.AuthUseCase
 import backend.team.ahachul_backend.api.member.domain.model.ProviderType
 import backend.team.ahachul_backend.common.properties.OAuthProperties
+import backend.team.ahachul_backend.common.response.CommonResponse
 import backend.team.ahachul_backend.config.controller.CommonDocsTestConfig
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
+import org.mockito.BDDMockito.willDoNothing
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.http.MediaType
@@ -117,6 +120,41 @@ class AuthControllerDocsTest : CommonDocsTestConfig() {
                         fieldWithPath("result.accessTokenExpiresIn").type(JsonFieldType.NUMBER).description("엑세스 토큰 만료 기간"),
                         fieldWithPath("result.refreshToken").type(JsonFieldType.STRING).description("리프레쉬 토큰. 만료 기간 : 30일"),
                         fieldWithPath("result.refreshTokenExpiresIn").type(JsonFieldType.NUMBER).description("리프레쉬 토큰 만료 기간"),
+                    )
+                ),
+            )
+    }
+
+    @Test
+    fun logoutTest() {
+        // given
+        willDoNothing().given(authUseCase).logout(any())
+
+        val request = LogoutMemberDto.Request(
+            accessToken = "accessToken"
+        )
+
+        // when
+        val result = mockMvc.perform(
+            post("/v1/auth/logout")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .accept(MediaType.APPLICATION_JSON)
+        )
+
+        // then
+        result.andExpect(status().isOk)
+            .andDo(
+                document(
+                    "logout",
+                    getDocsRequest(),
+                    getDocsResponse(),
+                    requestFields(
+                        fieldWithPath("accessToken").type(JsonFieldType.STRING).description("엑세스 토큰"),
+                    ),
+                    responseFields(
+                        *commonResponseFields(),
+                        fieldWithPath("result").optional().description("X")
                     )
                 ),
             )

--- a/application/src/test/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/AuthLogoutControllerTest.kt
+++ b/application/src/test/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/AuthLogoutControllerTest.kt
@@ -1,0 +1,49 @@
+package backend.team.ahachul_backend.api.member.adapter.web.`in`
+
+import backend.team.ahachul_backend.api.member.adapter.web.`in`.support.LogoutSupportTestController
+import backend.team.ahachul_backend.common.exception.CommonException
+import backend.team.ahachul_backend.common.interceptor.AuthenticationInterceptor
+import backend.team.ahachul_backend.common.response.ResponseCode
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.BDDMockito.given
+import org.mockito.Mockito
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest(LogoutSupportTestController::class)
+class AuthLogoutControllerTest {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @MockBean
+    lateinit var authenticationInterceptor: AuthenticationInterceptor
+
+    @BeforeEach
+    fun setup() {
+        given(authenticationInterceptor.preHandle(any(), any(), any()))
+            .willThrow(CommonException(ResponseCode.ALREADY_LOGOUT_TOKEN))
+    }
+
+    @Test
+    fun 로그아웃_토큰_요청시_예외발생() {
+        //when & then
+        mockMvc.perform(
+            get("/test/support/authenticated")
+                .header("Authorization", "Bearer logout-token")
+                .accept(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isInternalServerError)
+    }
+
+    fun <T> any(): T {
+        Mockito.any<T>()
+        return null as T
+    }
+}

--- a/application/src/test/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/support/LogoutSupportTestController.kt
+++ b/application/src/test/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/support/LogoutSupportTestController.kt
@@ -1,0 +1,16 @@
+package backend.team.ahachul_backend.api.member.adapter.web.`in`.support
+
+import backend.team.ahachul_backend.common.annotation.Authentication
+import backend.team.ahachul_backend.common.response.CommonResponse
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class LogoutSupportTestController {
+
+    @Authentication
+    @GetMapping("/test/support/authenticated")
+    fun authenticated(): CommonResponse<*> {
+        return CommonResponse.success()
+    }
+}

--- a/application/src/test/kotlin/backend/team/ahachul_backend/api/member/application/service/AuthServiceTest.kt
+++ b/application/src/test/kotlin/backend/team/ahachul_backend/api/member/application/service/AuthServiceTest.kt
@@ -1,0 +1,71 @@
+package backend.team.ahachul_backend.api.member.application.service
+
+import backend.team.ahachul_backend.api.member.application.port.`in`.AuthUseCase
+import backend.team.ahachul_backend.common.exception.CommonException
+import backend.team.ahachul_backend.common.response.ResponseCode
+import backend.team.ahachul_backend.common.utils.JwtUtils
+import backend.team.ahachul_backend.config.controller.CommonServiceTestConfig
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class AuthServiceTest(
+    @Autowired val authUseCase: AuthUseCase,
+    @Autowired val authLogoutCacheUtils: AuthLogoutCacheUtils,
+    @Autowired val jwtUtils: JwtUtils,
+) : CommonServiceTestConfig() {
+
+    @Test
+    fun 로그아웃_블랙리스트_저장() {
+        //given
+        val createToken = jwtUtils.createToken("test", 100L)
+
+        //when
+        authUseCase.logout(createToken);
+
+        //then
+        val notLogout = authLogoutCacheUtils.isNotLogout(createToken)
+        assertThat(notLogout).isFalse()
+    }
+
+    @Test
+    fun 로그아웃_유효하지_않는_JWT_예외() {
+        //given
+        val createToken = "test"
+
+        //when & then
+        assertThatThrownBy {
+            authUseCase.logout(createToken)
+        }
+            .isExactlyInstanceOf(CommonException::class.java)
+            .hasMessage(ResponseCode.INVALID_ACCESS_TOKEN.message)
+    }
+
+    @Test
+    fun 로그아웃_만료된_JWT_예외() {
+        //given
+        val createToken = jwtUtils.createToken("test", -86400L)
+
+        //when & then
+        assertThatThrownBy {
+            authUseCase.logout(createToken)
+        }
+            .isExactlyInstanceOf(CommonException::class.java)
+            .hasMessage(ResponseCode.EXPIRED_ACCESS_TOKEN.message)
+    }
+
+    @Test
+    fun 이미_로그아웃_처리된_토큰_예외() {
+        //given
+        val createToken = jwtUtils.createToken("test", 10L)
+        authUseCase.logout(createToken); // 로그아웃 처리
+
+        //when & then
+        assertThatThrownBy {
+            authUseCase.logout(createToken)
+        }
+            .isExactlyInstanceOf(CommonException::class.java)
+            .hasMessage(ResponseCode.ALREADY_LOGOUT_TOKEN.message)
+    }
+}

--- a/core/src/main/kotlin/backend/team/ahachul_backend/common/response/ResponseCode.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/common/response/ResponseCode.kt
@@ -23,6 +23,7 @@ enum class ResponseCode(
     INVALID_OAUTH_ACCESS_TOKEN("206", "유효하지 않은 액세스 토큰입니다.", HttpStatus.UNAUTHORIZED),
     INVALID_AUTH("207", "권한이 없습니다.", HttpStatus.FORBIDDEN),
     FAILED_TO_CONNECT_TO_REDIS("208", "통신 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    ALREADY_LOGOUT_TOKEN("209", "이미 로그아웃된 토큰입니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
 
     // REPORT


### PR DESCRIPTION
## 📚 개요
+ #313 

## ✏️ 작업 내용
+ Redis에 로그아웃 할 엑세스 토큰을 저장하며, 
다른 API 요청 시 해당 토큰으로 들어오면 Interceptor에서 예외처리 되게끔 작성하였습니다.
