### PR TITLE
♻️ 역 즐겨찾기 우선순위 적용 (#339)

### DIFF
--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/MemberController.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/MemberController.kt
@@ -40,7 +40,7 @@ class MemberController(
     @PostMapping("/v1/members/bookmarks/stations")
     fun bookmarkStation(
             @RequestBody request: BookmarkStationDto.Request
-    ): CommonResponse<BookmarkStationDto.Response> {
+    ): CommonResponse<GetBookmarkStationDto.Response> {
         return CommonResponse.success(memberUseCase.bookmarkStation(request.toCommand()))
     }
 

--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/dto/BookmarkStationDto.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/dto/BookmarkStationDto.kt
@@ -1,20 +1,26 @@
 package backend.team.ahachul_backend.api.member.adapter.web.`in`.dto
 
 import backend.team.ahachul_backend.api.member.application.command.BookmarkStationCommand
+import backend.team.ahachul_backend.api.member.application.command.BookmarkStationCommands
 
 class BookmarkStationDto {
 
     data class Request(
-        val stationNames: List<String>
+        val stations: List<BookmarkStation>
     ) {
-        fun toCommand(): BookmarkStationCommand {
-            return BookmarkStationCommand(
-                stationNames = stationNames.toMutableList()
+        fun toCommand(): BookmarkStationCommands {
+            return BookmarkStationCommands(
+                stations.map { BookmarkStationCommand(it.stationName, it.label) }
             )
         }
     }
 
     data class Response(
         val memberStationIds: List<Long>
+    )
+
+    data class BookmarkStation(
+        val stationName: String,
+        val label: String?,
     )
 }

--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/dto/BookmarkStationDto.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/dto/BookmarkStationDto.kt
@@ -1,6 +1,6 @@
 package backend.team.ahachul_backend.api.member.adapter.web.`in`.dto
 
-import backend.team.ahachul_backend.api.member.application.port.`in`.command.BookmarkStationCommand
+import backend.team.ahachul_backend.api.member.application.command.BookmarkStationCommand
 
 class BookmarkStationDto {
 

--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/dto/GetBookmarkStationDto.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/dto/GetBookmarkStationDto.kt
@@ -9,6 +9,7 @@ class GetBookmarkStationDto {
     data class StationInfo(
         val stationId: Long,
         val stationName: String,
+        val label: String?,
         val subwayLineInfoList: List<SubwayLineInfo>
     )
 

--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/in/MemberUseCase.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/in/MemberUseCase.kt
@@ -14,7 +14,7 @@ interface MemberUseCase {
 
     fun checkNickname(command: CheckNicknameCommand): CheckNicknameDto.Response
 
-    fun bookmarkStation(command: BookmarkStationCommands): BookmarkStationDto.Response
+    fun bookmarkStation(command: BookmarkStationCommands): GetBookmarkStationDto.Response
 
     fun getBookmarkStation(): GetBookmarkStationDto.Response
 

--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/in/MemberUseCase.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/in/MemberUseCase.kt
@@ -2,7 +2,7 @@ package backend.team.ahachul_backend.api.member.application.port.`in`
 
 import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.*
 import backend.team.ahachul_backend.api.member.application.command.SearchMemberCommand
-import backend.team.ahachul_backend.api.member.application.port.`in`.command.BookmarkStationCommand
+import backend.team.ahachul_backend.api.member.application.command.BookmarkStationCommand
 import backend.team.ahachul_backend.api.member.application.port.`in`.command.CheckNicknameCommand
 import backend.team.ahachul_backend.api.member.application.port.`in`.command.UpdateMemberCommand
 

--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/in/MemberUseCase.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/in/MemberUseCase.kt
@@ -2,7 +2,7 @@ package backend.team.ahachul_backend.api.member.application.port.`in`
 
 import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.*
 import backend.team.ahachul_backend.api.member.application.command.SearchMemberCommand
-import backend.team.ahachul_backend.api.member.application.command.BookmarkStationCommand
+import backend.team.ahachul_backend.api.member.application.command.BookmarkStationCommands
 import backend.team.ahachul_backend.api.member.application.port.`in`.command.CheckNicknameCommand
 import backend.team.ahachul_backend.api.member.application.port.`in`.command.UpdateMemberCommand
 
@@ -14,7 +14,7 @@ interface MemberUseCase {
 
     fun checkNickname(command: CheckNicknameCommand): CheckNicknameDto.Response
 
-    fun bookmarkStation(command: BookmarkStationCommand): BookmarkStationDto.Response
+    fun bookmarkStation(command: BookmarkStationCommands): BookmarkStationDto.Response
 
     fun getBookmarkStation(): GetBookmarkStationDto.Response
 

--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/member/application/service/MemberService.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/member/application/service/MemberService.kt
@@ -58,21 +58,12 @@ class MemberService(
         val bookmarkStations = command.stationNames
         val originMemberStations = memberStationReader.getByMember(member)
 
-        originMemberStations.forEach {
-            val stationName = it.station.name
-            if (isAlreadyExists(bookmarkStations, stationName)) {
-                bookmarkStations.remove(stationName)
-            } else {
-                memberStationWriter.delete(it.id)
-            }
+        if (originMemberStations.isNotEmpty()) {
+            memberStationWriter.deleteAllByMember(member)
         }
 
         val bookmarkStationIds = saveNewStations(member, bookmarkStations)
         return BookmarkStationDto.Response(bookmarkStationIds)
-    }
-
-    private fun isAlreadyExists(newNames: List<String>, originName: String): Boolean {
-        return newNames.contains(originName)
     }
 
     private fun saveNewStations(member: MemberEntity, bookmarkStations: List<String>): List<Long> {

--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/member/application/service/MemberService.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/member/application/service/MemberService.kt
@@ -15,6 +15,8 @@ import backend.team.ahachul_backend.api.member.application.port.out.MemberStatio
 import backend.team.ahachul_backend.api.member.application.port.out.MemberStationWriter
 import backend.team.ahachul_backend.api.member.domain.entity.MemberEntity
 import backend.team.ahachul_backend.api.member.domain.entity.MemberStationEntity
+import backend.team.ahachul_backend.common.exception.CommonException
+import backend.team.ahachul_backend.common.response.ResponseCode
 import backend.team.ahachul_backend.common.utils.RequestUtils
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -59,24 +61,16 @@ class MemberService(
         val bookmarkStations = command.stations
         val originMemberStations = memberStationReader.getByMember(member)
 
+        if (isAlreadyRegisteredStation(originMemberStations, bookmarkStations)) {
+            throw CommonException(ResponseCode.ALREADY_REGISTERED_STATION)
+        }
+
         if (originMemberStations.isNotEmpty()) {
             memberStationWriter.deleteAllByMember(member)
         }
 
         val bookmarkStationIds = saveNewStations(member, bookmarkStations)
         return BookmarkStationDto.Response(bookmarkStationIds)
-    }
-
-    private fun saveNewStations(member: MemberEntity, bookmarkStations: List<BookmarkStationCommand>): List<Long> {
-        return bookmarkStations
-            .map {
-                val memberStation = MemberStationEntity(
-                    member = member,
-                    station = stationReader.getByName(it.stationName),
-                    label = it.label
-                )
-                memberStationWriter.save(memberStation).id
-            }
     }
 
     override fun getBookmarkStation(): GetBookmarkStationDto.Response {
@@ -106,6 +100,31 @@ class MemberService(
         }
 
         return SearchMemberDto.Response.of(members)
+    }
+
+    private fun isAlreadyRegisteredStation(
+        originMemberStations: List<MemberStationEntity>,
+        bookmarkStations: List<BookmarkStationCommand>
+    ): Boolean {
+        if (originMemberStations.size != bookmarkStations.size) {
+            return false
+        }
+
+        return originMemberStations.indices.all {
+            originMemberStations[it].isEquals(bookmarkStations[it].stationName, bookmarkStations[it].label)
+        }
+    }
+
+    private fun saveNewStations(member: MemberEntity, bookmarkStations: List<BookmarkStationCommand>): List<Long> {
+        return bookmarkStations
+            .map {
+                val memberStation = MemberStationEntity(
+                    member = member,
+                    station = stationReader.getByName(it.stationName),
+                    label = it.label
+                )
+                memberStationWriter.save(memberStation).id
+            }
     }
 
     private fun getSubwayLineInfos(station: StationEntity): List<GetBookmarkStationDto.SubwayLineInfo> {

--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/member/application/service/MemberService.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/member/application/service/MemberService.kt
@@ -6,7 +6,7 @@ import backend.team.ahachul_backend.api.common.domain.entity.StationEntity
 import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.*
 import backend.team.ahachul_backend.api.member.application.command.SearchMemberCommand
 import backend.team.ahachul_backend.api.member.application.port.`in`.MemberUseCase
-import backend.team.ahachul_backend.api.member.application.port.`in`.command.BookmarkStationCommand
+import backend.team.ahachul_backend.api.member.application.command.BookmarkStationCommand
 import backend.team.ahachul_backend.api.member.application.port.`in`.command.CheckNicknameCommand
 import backend.team.ahachul_backend.api.member.application.port.`in`.command.UpdateMemberCommand
 import backend.team.ahachul_backend.api.member.application.port.out.MemberReader

--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/member/application/service/MemberService.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/member/application/service/MemberService.kt
@@ -15,8 +15,6 @@ import backend.team.ahachul_backend.api.member.application.port.out.MemberStatio
 import backend.team.ahachul_backend.api.member.application.port.out.MemberStationWriter
 import backend.team.ahachul_backend.api.member.domain.entity.MemberEntity
 import backend.team.ahachul_backend.api.member.domain.entity.MemberStationEntity
-import backend.team.ahachul_backend.common.exception.CommonException
-import backend.team.ahachul_backend.common.response.ResponseCode
 import backend.team.ahachul_backend.common.utils.RequestUtils
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -56,39 +54,27 @@ class MemberService(
     }
 
     @Transactional
-    override fun bookmarkStation(command: BookmarkStationCommands): BookmarkStationDto.Response {
+    override fun bookmarkStation(command: BookmarkStationCommands): GetBookmarkStationDto.Response {
         val member = memberReader.getMember(RequestUtils.getAttribute("memberId")!!.toLong())
-        val bookmarkStations = command.stations
-        val originMemberStations = memberStationReader.getByMember(member)
+        val bookmarkStations = memberStationReader.getByMember(member)
 
-        if (isAlreadyRegisteredStation(originMemberStations, bookmarkStations)) {
-            throw CommonException(ResponseCode.ALREADY_REGISTERED_STATION)
+        if (isEqualsAlreadyRegisteredStation(bookmarkStations, command.stations)) {
+            return createBookmarkStationResponse(bookmarkStations)
         }
 
-        if (originMemberStations.isNotEmpty()) {
+        if (bookmarkStations.isNotEmpty()) {
             memberStationWriter.deleteAllByMember(member)
         }
 
-        val bookmarkStationIds = saveNewStations(member, bookmarkStations)
-        return BookmarkStationDto.Response(bookmarkStationIds)
+        val savedMemberStations = saveNewStations(member, command.stations)
+        return createBookmarkStationResponse(savedMemberStations)
     }
 
     override fun getBookmarkStation(): GetBookmarkStationDto.Response {
         val member = memberReader.getMember(RequestUtils.getAttribute("memberId")!!.toLong())
-
         val bookmarkStations = memberStationReader.getByMember(member)
-        val stationInfos = bookmarkStations
-            .map {
-                val station = it.station
-                GetBookmarkStationDto.StationInfo(
-                    stationId = station.id,
-                    stationName = station.name,
-                    label = it.label,
-                    subwayLineInfoList = getSubwayLineInfos(station)
-                )
-            }
 
-        return GetBookmarkStationDto.Response(stationInfos)
+        return createBookmarkStationResponse(bookmarkStations)
     }
 
     override fun searchMembers(command: SearchMemberCommand): SearchMemberDto.Response {
@@ -102,20 +88,20 @@ class MemberService(
         return SearchMemberDto.Response.of(members)
     }
 
-    private fun isAlreadyRegisteredStation(
+    private fun isEqualsAlreadyRegisteredStation(
         originMemberStations: List<MemberStationEntity>,
-        bookmarkStations: List<BookmarkStationCommand>
+        newBookmarkStationCommands: List<BookmarkStationCommand>
     ): Boolean {
-        if (originMemberStations.size != bookmarkStations.size) {
+        if (originMemberStations.size != newBookmarkStationCommands.size) {
             return false
         }
 
         return originMemberStations.indices.all {
-            originMemberStations[it].isEquals(bookmarkStations[it].stationName, bookmarkStations[it].label)
+            originMemberStations[it].isEquals(newBookmarkStationCommands[it].stationName, newBookmarkStationCommands[it].label)
         }
     }
 
-    private fun saveNewStations(member: MemberEntity, bookmarkStations: List<BookmarkStationCommand>): List<Long> {
+    private fun saveNewStations(member: MemberEntity, bookmarkStations: List<BookmarkStationCommand>): List<MemberStationEntity> {
         return bookmarkStations
             .map {
                 val memberStation = MemberStationEntity(
@@ -123,8 +109,23 @@ class MemberService(
                     station = stationReader.getByName(it.stationName),
                     label = it.label
                 )
-                memberStationWriter.save(memberStation).id
+                memberStationWriter.save(memberStation)
             }
+    }
+
+    private fun createBookmarkStationResponse(memberStations: List<MemberStationEntity>): GetBookmarkStationDto.Response {
+        val stationInfos = memberStations
+            .map {
+                val station = it.station
+                GetBookmarkStationDto.StationInfo(
+                    stationId = station.id,
+                    stationName = station.name,
+                    label = it.label,
+                    subwayLineInfoList = getSubwayLineInfos(station)
+                )
+            }
+
+        return GetBookmarkStationDto.Response(stationInfos)
     }
 
     private fun getSubwayLineInfos(station: StationEntity): List<GetBookmarkStationDto.SubwayLineInfo> {

--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/member/application/service/MemberService.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/member/application/service/MemberService.kt
@@ -4,9 +4,10 @@ import backend.team.ahachul_backend.api.common.application.port.out.StationReade
 import backend.team.ahachul_backend.api.common.application.port.out.SubwayLineStationReader
 import backend.team.ahachul_backend.api.common.domain.entity.StationEntity
 import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.*
+import backend.team.ahachul_backend.api.member.application.command.BookmarkStationCommand
 import backend.team.ahachul_backend.api.member.application.command.SearchMemberCommand
 import backend.team.ahachul_backend.api.member.application.port.`in`.MemberUseCase
-import backend.team.ahachul_backend.api.member.application.command.BookmarkStationCommand
+import backend.team.ahachul_backend.api.member.application.command.BookmarkStationCommands
 import backend.team.ahachul_backend.api.member.application.port.`in`.command.CheckNicknameCommand
 import backend.team.ahachul_backend.api.member.application.port.`in`.command.UpdateMemberCommand
 import backend.team.ahachul_backend.api.member.application.port.out.MemberReader
@@ -53,9 +54,9 @@ class MemberService(
     }
 
     @Transactional
-    override fun bookmarkStation(command: BookmarkStationCommand): BookmarkStationDto.Response {
+    override fun bookmarkStation(command: BookmarkStationCommands): BookmarkStationDto.Response {
         val member = memberReader.getMember(RequestUtils.getAttribute("memberId")!!.toLong())
-        val bookmarkStations = command.stationNames
+        val bookmarkStations = command.stations
         val originMemberStations = memberStationReader.getByMember(member)
 
         if (originMemberStations.isNotEmpty()) {
@@ -66,13 +67,13 @@ class MemberService(
         return BookmarkStationDto.Response(bookmarkStationIds)
     }
 
-    private fun saveNewStations(member: MemberEntity, bookmarkStations: List<String>): List<Long> {
+    private fun saveNewStations(member: MemberEntity, bookmarkStations: List<BookmarkStationCommand>): List<Long> {
         return bookmarkStations
-            .map { stationReader.getByName(it) }
-            .map { station ->
+            .map {
                 val memberStation = MemberStationEntity(
-                        member = member,
-                        station = station
+                    member = member,
+                    station = stationReader.getByName(it.stationName),
+                    label = it.label
                 )
                 memberStationWriter.save(memberStation).id
             }
@@ -86,9 +87,10 @@ class MemberService(
             .map {
                 val station = it.station
                 GetBookmarkStationDto.StationInfo(
-                        stationId = station.id,
-                        stationName = station.name,
-                        subwayLineInfoList = getSubwayLineInfos(station)
+                    stationId = station.id,
+                    stationName = station.name,
+                    label = it.label,
+                    subwayLineInfoList = getSubwayLineInfos(station)
                 )
             }
 
@@ -106,12 +108,12 @@ class MemberService(
         return SearchMemberDto.Response.of(members)
     }
 
-    private fun getSubwayLineInfos(station: StationEntity): List<GetBookmarkStationDto.SubwayLineInfo>{
+    private fun getSubwayLineInfos(station: StationEntity): List<GetBookmarkStationDto.SubwayLineInfo> {
         val subwayLineStations = subwayLineStationReader.findByStation(station)
         return subwayLineStations.map {
             GetBookmarkStationDto.SubwayLineInfo(
-                    subwayLineId = it.subwayLine.id,
-                    subwayLineName = it.subwayLine.name
+                subwayLineId = it.subwayLine.id,
+                subwayLineName = it.subwayLine.name
             )
         }
     }

--- a/application/src/test/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/MemberControllerDocsTest.kt
+++ b/application/src/test/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/MemberControllerDocsTest.kt
@@ -1,6 +1,7 @@
 package backend.team.ahachul_backend.api.member.adapter.web.`in`
 
 import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.*
+import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.BookmarkStationDto.BookmarkStation
 import backend.team.ahachul_backend.api.member.application.port.`in`.MemberUseCase
 import backend.team.ahachul_backend.api.member.domain.model.GenderType
 import backend.team.ahachul_backend.config.controller.CommonDocsTestConfig
@@ -169,7 +170,11 @@ class MemberControllerDocsTest : CommonDocsTestConfig() {
         given(memberUseCase.bookmarkStation(any()))
                 .willReturn(response)
 
-        val request = BookmarkStationDto.Request(listOf("발산역", "우장산역", "화곡역"))
+        val request = BookmarkStationDto.Request(listOf(
+            BookmarkStation("발산역", "집"),
+            BookmarkStation("우장산역", "학교"),
+            BookmarkStation("화곡역", "즐겨찾는 장소"),
+        ))
 
         // when
         val result = mockMvc.perform(
@@ -187,7 +192,9 @@ class MemberControllerDocsTest : CommonDocsTestConfig() {
                     getDocsRequest(),
                     getDocsResponse(),
                     requestFields(
-                        fieldWithPath("stationNames").type(JsonFieldType.ARRAY).description("즐겨찾는 역 이름 리스트"),
+                        fieldWithPath("stations").type(JsonFieldType.ARRAY).description("즐겨찾는 역 이름 및 별명 리스트"),
+                        fieldWithPath("stations[].stationName").type(JsonFieldType.STRING).description("즐겨찾는 역 이름"),
+                        fieldWithPath("stations[].label").type(JsonFieldType.STRING).description("즐겨찾는 역 별명").optional(),
                     ),
                     responseFields(
                         *commonResponseFields(),
@@ -205,6 +212,7 @@ class MemberControllerDocsTest : CommonDocsTestConfig() {
                 GetBookmarkStationDto.StationInfo(
                     stationId = 1L,
                     stationName = "시청역",
+                    label = "집",
                     subwayLineInfoList = listOf(
                         GetBookmarkStationDto.SubwayLineInfo(
                             subwayLineId = 1L,
@@ -236,6 +244,7 @@ class MemberControllerDocsTest : CommonDocsTestConfig() {
                         fieldWithPath("result.stationInfoList").type(JsonFieldType.ARRAY).description("즐겨찾기 한 역 정보 리스트"),
                         fieldWithPath("result.stationInfoList[].stationId").type(JsonFieldType.NUMBER).description("역 고유 ID"),
                         fieldWithPath("result.stationInfoList[].stationName").type(JsonFieldType.STRING).description("역 이름"),
+                        fieldWithPath("result.stationInfoList[].label").type(JsonFieldType.STRING).description("역 별명").optional(),
                         fieldWithPath("result.stationInfoList[].subwayLineInfoList").type(JsonFieldType.ARRAY).description("해당 역이 존재하는 노선 리스트"),
                         fieldWithPath("result.stationInfoList[].subwayLineInfoList[].subwayLineId").type(JsonFieldType.NUMBER).description("노선 고유 ID"),
                         fieldWithPath("result.stationInfoList[].subwayLineInfoList[].subwayLineName").type(JsonFieldType.STRING).description("노선 이름"),

--- a/application/src/test/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/MemberControllerDocsTest.kt
+++ b/application/src/test/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/MemberControllerDocsTest.kt
@@ -166,7 +166,44 @@ class MemberControllerDocsTest : CommonDocsTestConfig() {
     @Test
     fun bookmarkStationTest() {
         // given
-        val response = BookmarkStationDto.Response(listOf(1L, 2L, 3L))
+        val response = GetBookmarkStationDto.Response(
+            stationInfoList = listOf(
+                GetBookmarkStationDto.StationInfo(
+                    stationId = 1L,
+                    stationName = "발산역",
+                    label = "집",
+                    subwayLineInfoList = listOf(
+                        GetBookmarkStationDto.SubwayLineInfo(
+                            subwayLineId = 1L,
+                            subwayLineName = "1호선"
+                        )
+                    )
+                ),
+                GetBookmarkStationDto.StationInfo(
+                    stationId = 2L,
+                    stationName = "우장산역",
+                    label = "학교",
+                    subwayLineInfoList = listOf(
+                        GetBookmarkStationDto.SubwayLineInfo(
+                            subwayLineId = 5L,
+                            subwayLineName = "5호선"
+                        )
+                    )
+                ),
+                GetBookmarkStationDto.StationInfo(
+                    stationId = 3L,
+                    stationName = "화곡역",
+                    label = "즐겨찾는 장소",
+                    subwayLineInfoList = listOf(
+                        GetBookmarkStationDto.SubwayLineInfo(
+                            subwayLineId = 1L,
+                            subwayLineName = "1호선"
+                        )
+                    )
+                )
+            )
+        )
+
         given(memberUseCase.bookmarkStation(any()))
                 .willReturn(response)
 
@@ -198,7 +235,13 @@ class MemberControllerDocsTest : CommonDocsTestConfig() {
                     ),
                     responseFields(
                         *commonResponseFields(),
-                        fieldWithPath("result.memberStationIds").type(JsonFieldType.ARRAY).description("즐겨찾는 역 ID 리스트"),
+                        fieldWithPath("result.stationInfoList").type(JsonFieldType.ARRAY).description("즐겨찾기 한 역 정보 리스트"),
+                        fieldWithPath("result.stationInfoList[].stationId").type(JsonFieldType.NUMBER).description("역 고유 ID"),
+                        fieldWithPath("result.stationInfoList[].stationName").type(JsonFieldType.STRING).description("역 이름"),
+                        fieldWithPath("result.stationInfoList[].label").type(JsonFieldType.STRING).description("역 별명").optional(),
+                        fieldWithPath("result.stationInfoList[].subwayLineInfoList").type(JsonFieldType.ARRAY).description("해당 역이 존재하는 노선 리스트"),
+                        fieldWithPath("result.stationInfoList[].subwayLineInfoList[].subwayLineId").type(JsonFieldType.NUMBER).description("노선 고유 ID"),
+                        fieldWithPath("result.stationInfoList[].subwayLineInfoList[].subwayLineName").type(JsonFieldType.STRING).description("노선 이름"),
                     )
                 )
             )

--- a/application/src/test/kotlin/backend/team/ahachul_backend/api/member/application/service/MemberServiceTest.kt
+++ b/application/src/test/kotlin/backend/team/ahachul_backend/api/member/application/service/MemberServiceTest.kt
@@ -201,7 +201,45 @@ class MemberServiceTest(
         val result = memberUseCase.bookmarkStation(command)
 
         // then
-        assertThat(result.memberStationIds.size).isEqualTo(1)  // new bookmark
+        assertThat(result.memberStationIds.size).isEqualTo(2)  // new bookmark
+    }
+
+    @Test
+    fun 즐겨찾기_역_수정_시_순서_유지() {
+        // given
+        val stationList = listOf(
+            StationEntity(name = "시청역"),
+            StationEntity(name = "발산역"),
+            StationEntity(name = "강남역"),
+            StationEntity(name = "우장산역")
+        )
+
+        stationList.forEach {
+            stationRepository.save(it)
+        }
+
+        stationList.subList(0, 2).forEach {     // origin bookmark
+            memberStationRepository.save(
+                MemberStationEntity(
+                    member = member!!,
+                    station = it
+                )
+            )
+        }
+
+        val command = BookmarkStationCommand(
+            stationNames = mutableListOf("발산역", "시청역", "강남역")
+        )
+
+        // when
+        memberUseCase.bookmarkStation(command)
+
+        // then
+        val result = memberUseCase.getBookmarkStation()
+        assertThat(result.stationInfoList.size).isEqualTo(3)
+        assertThat(result.stationInfoList[0].stationName).isEqualTo("발산역")
+        assertThat(result.stationInfoList[1].stationName).isEqualTo("시청역")
+        assertThat(result.stationInfoList[2].stationName).isEqualTo("강남역")
     }
 
     @Test

--- a/application/src/test/kotlin/backend/team/ahachul_backend/api/member/application/service/MemberServiceTest.kt
+++ b/application/src/test/kotlin/backend/team/ahachul_backend/api/member/application/service/MemberServiceTest.kt
@@ -21,6 +21,7 @@ import backend.team.ahachul_backend.api.member.domain.model.ProviderType
 import backend.team.ahachul_backend.common.domain.entity.SubwayLineEntity
 import backend.team.ahachul_backend.common.domain.model.RegionType
 import backend.team.ahachul_backend.common.exception.BusinessException
+import backend.team.ahachul_backend.common.exception.CommonException
 import backend.team.ahachul_backend.common.persistence.SubwayLineRepository
 import backend.team.ahachul_backend.common.response.ResponseCode
 import backend.team.ahachul_backend.common.utils.RequestUtils
@@ -259,6 +260,41 @@ class MemberServiceTest(
                 tuple("우장산역", "즐겨찾는 장소"),
                 tuple("발산역", "학교"),
             )
+    }
+
+    @Test
+    fun 이미_등록된_즐겨찾기_역_정보와_동일한_정보로_수정_요청하지_못한다() {
+        // given
+        val station1 = StationEntity(name = "시청역")
+        val station2 = StationEntity(name = "강남역")
+
+        stationRepository.saveAll(listOf(station1, station2))
+
+        val memberStation1 = MemberStationEntity(
+            member = member!!,
+            station = station1,
+            label = "집"
+        )
+
+        val memberStation2 = MemberStationEntity(
+            member = member!!,
+            station = station2,
+            label = "직장"
+        )
+
+        memberStationRepository.saveAll(listOf(memberStation1, memberStation2))
+
+        val command = BookmarkStationCommands(
+            stations = listOf(
+                BookmarkStationCommand("시청역", "집"),
+                BookmarkStationCommand("강남역", "직장"),
+            )
+        )
+
+        // when & then
+        assertThatThrownBy { memberUseCase.bookmarkStation(command) }
+            .isExactlyInstanceOf(CommonException::class.java)
+            .hasMessage("이미 등록된 즐겨찾기 역 정보와 동일합니다.")
     }
 
     @Test

--- a/application/src/test/kotlin/backend/team/ahachul_backend/api/member/application/service/MemberServiceTest.kt
+++ b/application/src/test/kotlin/backend/team/ahachul_backend/api/member/application/service/MemberServiceTest.kt
@@ -8,7 +8,7 @@ import backend.team.ahachul_backend.api.member.adapter.web.out.MemberRepository
 import backend.team.ahachul_backend.api.member.adapter.web.out.MemberStationRepository
 import backend.team.ahachul_backend.api.member.application.command.SearchMemberCommand
 import backend.team.ahachul_backend.api.member.application.port.`in`.MemberUseCase
-import backend.team.ahachul_backend.api.member.application.port.`in`.command.BookmarkStationCommand
+import backend.team.ahachul_backend.api.member.application.command.BookmarkStationCommand
 import backend.team.ahachul_backend.api.member.application.port.`in`.command.CheckNicknameCommand
 import backend.team.ahachul_backend.api.member.application.port.`in`.command.UpdateMemberCommand
 import backend.team.ahachul_backend.api.member.application.port.out.MemberWriter

--- a/application/src/test/kotlin/backend/team/ahachul_backend/api/member/application/service/MemberServiceTest.kt
+++ b/application/src/test/kotlin/backend/team/ahachul_backend/api/member/application/service/MemberServiceTest.kt
@@ -6,9 +6,10 @@ import backend.team.ahachul_backend.api.common.domain.entity.StationEntity
 import backend.team.ahachul_backend.api.common.domain.entity.SubwayLineStationEntity
 import backend.team.ahachul_backend.api.member.adapter.web.out.MemberRepository
 import backend.team.ahachul_backend.api.member.adapter.web.out.MemberStationRepository
+import backend.team.ahachul_backend.api.member.application.command.BookmarkStationCommand
 import backend.team.ahachul_backend.api.member.application.command.SearchMemberCommand
 import backend.team.ahachul_backend.api.member.application.port.`in`.MemberUseCase
-import backend.team.ahachul_backend.api.member.application.command.BookmarkStationCommand
+import backend.team.ahachul_backend.api.member.application.command.BookmarkStationCommands
 import backend.team.ahachul_backend.api.member.application.port.`in`.command.CheckNicknameCommand
 import backend.team.ahachul_backend.api.member.application.port.`in`.command.UpdateMemberCommand
 import backend.team.ahachul_backend.api.member.application.port.out.MemberWriter
@@ -24,8 +25,7 @@ import backend.team.ahachul_backend.common.persistence.SubwayLineRepository
 import backend.team.ahachul_backend.common.response.ResponseCode
 import backend.team.ahachul_backend.common.utils.RequestUtils
 import backend.team.ahachul_backend.config.controller.CommonServiceTestConfig
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -159,8 +159,12 @@ class MemberServiceTest(
         )
         stations.forEach { stationRepository.save(it) }
 
-        val command = BookmarkStationCommand(
-            stationNames = mutableListOf("시청역", "발산역", "강남역")
+        val command = BookmarkStationCommands(
+            stations = listOf(
+                BookmarkStationCommand("시청역", ""),
+                BookmarkStationCommand("발산역", "집"),
+                BookmarkStationCommand("강남역", "회사"),
+            )
         )
 
         // when
@@ -188,20 +192,23 @@ class MemberServiceTest(
             memberStationRepository.save(
                 MemberStationEntity(
                     member = member!!,
-                    station = it
+                    station = it,
+                    label = ""
                 )
             )
         }
 
-        val command = BookmarkStationCommand(
-            stationNames = mutableListOf("발산역", "우장산역")
+        val command = BookmarkStationCommands(
+            stations = listOf(
+                BookmarkStationCommand("시청역", "집"),
+            )
         )
 
         // when
         val result = memberUseCase.bookmarkStation(command)
 
         // then
-        assertThat(result.memberStationIds.size).isEqualTo(2)  // new bookmark
+        assertThat(result.memberStationIds.size).isEqualTo(1)  // new bookmark
     }
 
     @Test
@@ -222,13 +229,19 @@ class MemberServiceTest(
             memberStationRepository.save(
                 MemberStationEntity(
                     member = member!!,
-                    station = it
+                    station = it,
+                    label = ""
                 )
             )
         }
 
-        val command = BookmarkStationCommand(
-            stationNames = mutableListOf("발산역", "시청역", "강남역")
+        val command = BookmarkStationCommands(
+            stations = listOf(
+                BookmarkStationCommand("시청역", "회사"),
+                BookmarkStationCommand("강남역", "집"),
+                BookmarkStationCommand("우장산역", "즐겨찾는 장소"),
+                BookmarkStationCommand("발산역", "학교"),
+            )
         )
 
         // when
@@ -236,19 +249,30 @@ class MemberServiceTest(
 
         // then
         val result = memberUseCase.getBookmarkStation()
-        assertThat(result.stationInfoList.size).isEqualTo(3)
-        assertThat(result.stationInfoList[0].stationName).isEqualTo("발산역")
-        assertThat(result.stationInfoList[1].stationName).isEqualTo("시청역")
-        assertThat(result.stationInfoList[2].stationName).isEqualTo("강남역")
+        assertThat(result.stationInfoList.size).isEqualTo(4)
+
+        assertThat(result.stationInfoList)
+            .extracting("stationName", "label")
+            .containsExactly(
+                tuple("시청역", "회사"),
+                tuple("강남역", "집"),
+                tuple("우장산역", "즐겨찾는 장소"),
+                tuple("발산역", "학교"),
+            )
     }
 
     @Test
-    fun 즐겨찾는_역이_3개_이상이면_실패() {
-        // given
+    fun 즐겨찾는_역이_4개_보다_크면_실패() {
         // when + then
         assertThatThrownBy {
-            BookmarkStationCommand(
-                stationNames = mutableListOf("시청역", "발산역", "강남역", "구로역")
+            BookmarkStationCommands(
+                stations = listOf(
+                    BookmarkStationCommand("시청역", "회사"),
+                    BookmarkStationCommand("강남역", "집"),
+                    BookmarkStationCommand("우장산역", "즐겨찾는 장소"),
+                    BookmarkStationCommand("발산역", "학교"),
+                    BookmarkStationCommand("양재역", ""),
+                )
             )
         }
             .isExactlyInstanceOf(BusinessException::class.java)
@@ -270,7 +294,8 @@ class MemberServiceTest(
             memberStationRepository.save(
                 MemberStationEntity(
                     member = member!!,
-                    station = stationEntity
+                    station = stationEntity,
+                    label = ""
                 )
             )
             subwayLineStationRepository.save(

--- a/application/src/test/kotlin/backend/team/ahachul_backend/api/member/application/service/MemberServiceTest.kt
+++ b/application/src/test/kotlin/backend/team/ahachul_backend/api/member/application/service/MemberServiceTest.kt
@@ -7,9 +7,9 @@ import backend.team.ahachul_backend.api.common.domain.entity.SubwayLineStationEn
 import backend.team.ahachul_backend.api.member.adapter.web.out.MemberRepository
 import backend.team.ahachul_backend.api.member.adapter.web.out.MemberStationRepository
 import backend.team.ahachul_backend.api.member.application.command.BookmarkStationCommand
+import backend.team.ahachul_backend.api.member.application.command.BookmarkStationCommands
 import backend.team.ahachul_backend.api.member.application.command.SearchMemberCommand
 import backend.team.ahachul_backend.api.member.application.port.`in`.MemberUseCase
-import backend.team.ahachul_backend.api.member.application.command.BookmarkStationCommands
 import backend.team.ahachul_backend.api.member.application.port.`in`.command.CheckNicknameCommand
 import backend.team.ahachul_backend.api.member.application.port.`in`.command.UpdateMemberCommand
 import backend.team.ahachul_backend.api.member.application.port.out.MemberWriter
@@ -21,7 +21,6 @@ import backend.team.ahachul_backend.api.member.domain.model.ProviderType
 import backend.team.ahachul_backend.common.domain.entity.SubwayLineEntity
 import backend.team.ahachul_backend.common.domain.model.RegionType
 import backend.team.ahachul_backend.common.exception.BusinessException
-import backend.team.ahachul_backend.common.exception.CommonException
 import backend.team.ahachul_backend.common.persistence.SubwayLineRepository
 import backend.team.ahachul_backend.common.response.ResponseCode
 import backend.team.ahachul_backend.common.utils.RequestUtils
@@ -172,7 +171,7 @@ class MemberServiceTest(
         val result = memberUseCase.bookmarkStation(command)
 
         // then
-        assertThat(result.memberStationIds.size).isEqualTo(3)
+        assertThat(result.stationInfoList.size).isEqualTo(3)
     }
 
     @Test
@@ -209,7 +208,7 @@ class MemberServiceTest(
         val result = memberUseCase.bookmarkStation(command)
 
         // then
-        assertThat(result.memberStationIds.size).isEqualTo(1)  // new bookmark
+        assertThat(result.stationInfoList.size).isEqualTo(1)  // new bookmark
     }
 
     @Test
@@ -263,7 +262,7 @@ class MemberServiceTest(
     }
 
     @Test
-    fun 이미_등록된_즐겨찾기_역_정보와_동일한_정보로_수정_요청하지_못한다() {
+    fun 이미_등록된_즐겨찾기_역_정보와_동일한_정보로_수정_요청시_변경하지_않는다() {
         // given
         val station1 = StationEntity(name = "시청역")
         val station2 = StationEntity(name = "강남역")
@@ -291,10 +290,17 @@ class MemberServiceTest(
             )
         )
 
-        // when & then
-        assertThatThrownBy { memberUseCase.bookmarkStation(command) }
-            .isExactlyInstanceOf(CommonException::class.java)
-            .hasMessage("이미 등록된 즐겨찾기 역 정보와 동일합니다.")
+        // when
+        val result = memberUseCase.bookmarkStation(command)
+
+        // then
+        assertThat(result.stationInfoList.size).isEqualTo(2)
+        assertThat(result.stationInfoList[0].stationId).isEqualTo(memberStation1.station.id)
+        assertThat(result.stationInfoList[0].stationName).isEqualTo(memberStation1.station.name)
+        assertThat(result.stationInfoList[0].label).isEqualTo(memberStation1.label)
+        assertThat(result.stationInfoList[1].stationId).isEqualTo(memberStation2.station.id)
+        assertThat(result.stationInfoList[1].stationName).isEqualTo(memberStation2.station.name)
+        assertThat(result.stationInfoList[1].label).isEqualTo(memberStation2.label)
     }
 
     @Test

--- a/core/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/out/MemberStationPersistence.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/out/MemberStationPersistence.kt
@@ -11,8 +11,8 @@ class MemberStationPersistence (
     private val memberStationRepository: MemberStationRepository
 ): MemberStationReader, MemberStationWriter {
 
-    override fun delete(id: Long) {
-        memberStationRepository.deleteById(id)
+    override fun deleteAllByMember(member: MemberEntity) {
+        memberStationRepository.deleteAllByMember(member)
     }
 
     override fun save(entity: MemberStationEntity): MemberStationEntity {

--- a/core/src/main/kotlin/backend/team/ahachul_backend/api/member/application/command/BookmarkStationCommand.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/api/member/application/command/BookmarkStationCommand.kt
@@ -1,18 +1,6 @@
 package backend.team.ahachul_backend.api.member.application.command
 
-import backend.team.ahachul_backend.common.exception.BusinessException
-import backend.team.ahachul_backend.common.response.ResponseCode
-
 data class BookmarkStationCommand(
-    val stationNames: MutableList<String>
-) {
-    init {
-        if (stationNames.size > MAX_STATION_COUNT) {
-            throw BusinessException(ResponseCode.EXCEED_MAXIMUM_STATION_COUNT)
-        }
-    }
-
-    companion object {
-        const val MAX_STATION_COUNT = 3
-    }
-}
+    val stationName: String,
+    val label: String?
+)

--- a/core/src/main/kotlin/backend/team/ahachul_backend/api/member/application/command/BookmarkStationCommand.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/api/member/application/command/BookmarkStationCommand.kt
@@ -1,4 +1,4 @@
-package backend.team.ahachul_backend.api.member.application.port.`in`.command
+package backend.team.ahachul_backend.api.member.application.command
 
 import backend.team.ahachul_backend.common.exception.BusinessException
 import backend.team.ahachul_backend.common.response.ResponseCode

--- a/core/src/main/kotlin/backend/team/ahachul_backend/api/member/application/command/BookmarkStationCommands.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/api/member/application/command/BookmarkStationCommands.kt
@@ -1,0 +1,18 @@
+package backend.team.ahachul_backend.api.member.application.command
+
+import backend.team.ahachul_backend.common.exception.BusinessException
+import backend.team.ahachul_backend.common.response.ResponseCode
+
+data class BookmarkStationCommands(
+    val stations: List<BookmarkStationCommand>
+) {
+    init {
+        if (stations.size > MAX_STATION_COUNT) {
+            throw BusinessException(ResponseCode.EXCEED_MAXIMUM_STATION_COUNT)
+        }
+    }
+
+    companion object {
+        const val MAX_STATION_COUNT = 4
+    }
+}

--- a/core/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/out/MemberStationWriter.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/out/MemberStationWriter.kt
@@ -1,10 +1,11 @@
 package backend.team.ahachul_backend.api.member.application.port.out
 
+import backend.team.ahachul_backend.api.member.domain.entity.MemberEntity
 import backend.team.ahachul_backend.api.member.domain.entity.MemberStationEntity
 
 interface MemberStationWriter {
 
-    fun delete(id: Long)
+    fun deleteAllByMember(member: MemberEntity)
 
     fun save(entity: MemberStationEntity): MemberStationEntity
 }

--- a/core/src/main/kotlin/backend/team/ahachul_backend/api/member/domain/entity/MemberStationEntity.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/api/member/domain/entity/MemberStationEntity.kt
@@ -23,4 +23,8 @@ class MemberStationEntity(
     val station: StationEntity
 
 ): BaseEntity() {
+
+    fun isEquals(stationName: String, label: String?) : Boolean {
+        return this.station.name == stationName && this.label == label
+    }
 }

--- a/core/src/main/kotlin/backend/team/ahachul_backend/api/member/domain/entity/MemberStationEntity.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/api/member/domain/entity/MemberStationEntity.kt
@@ -12,6 +12,8 @@ class MemberStationEntity(
     @Column(name = "member_station_id")
     val id: Long = 0,
 
+    var label: String?,
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     val member: MemberEntity,

--- a/core/src/main/kotlin/backend/team/ahachul_backend/common/response/ResponseCode.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/common/response/ResponseCode.kt
@@ -53,7 +53,8 @@ enum class ResponseCode(
     FAILED_TO_GET_CONGESTION_INFO("705", "현재 혼잡도 정보를 받을 수 없습니다.", HttpStatus.NOT_FOUND),
 
     // STATION
-    EXCEED_MAXIMUM_STATION_COUNT("800", "즐겨찾는 역은 최대 3개까지 가능합니다.", HttpStatus.BAD_REQUEST),
+    EXCEED_MAXIMUM_STATION_COUNT("800", "즐겨찾는 역은 최대 4개까지 가능합니다.", HttpStatus.BAD_REQUEST),
+    ALREADY_REGISTERED_STATION("801", "이미 등록된 즐겨찾기 역 정보와 동일합니다.", HttpStatus.BAD_REQUEST),
 
     // FILE
     FILE_READ_FAILED("800", "파일 읽기에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);

--- a/core/src/main/kotlin/backend/team/ahachul_backend/common/response/ResponseCode.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/common/response/ResponseCode.kt
@@ -54,7 +54,6 @@ enum class ResponseCode(
 
     // STATION
     EXCEED_MAXIMUM_STATION_COUNT("800", "즐겨찾는 역은 최대 4개까지 가능합니다.", HttpStatus.BAD_REQUEST),
-    ALREADY_REGISTERED_STATION("801", "이미 등록된 즐겨찾기 역 정보와 동일합니다.", HttpStatus.BAD_REQUEST),
 
     // FILE
     FILE_READ_FAILED("800", "파일 읽기에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);

--- a/core/src/main/resources/db/migration/V202502191200__add_label_column.sql
+++ b/core/src/main/resources/db/migration/V202502191200__add_label_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tb_member_station
+    ADD COLUMN label VARCHAR(100) NULL AFTER member_station_id;


### PR DESCRIPTION
## 📚 개요
+ #339 

## ✏️ 작업 내용
+ 역 즐겨찾기 우선순위 적용
+ 역 즐겨찾기 라벨 추가 (추가)
+ 역 즐겨찾기 최대 개수 3개에서 4개로 변경 (추가)

## 💡 주의 사항
+ 기존 방식과 달리, 새롭게 등록 요청이 오면 기존에 등록된 정보를 새롭게 저장하여 우선순위를 유지 합니다. 
+ 혹시 다른 의견이 있으시면! 자유롭게 말씀해주세요!! 
