### PR TITLE
:bug: 실시간 열차 도착 정보 조회 API 버그 수정 (#342)

### DIFF
--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/train/application/service/TrainService.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/train/application/service/TrainService.kt
@@ -94,7 +94,7 @@ class TrainService(
      * Redis 통신 오류에 대한 FallBack 메서드
      */
     fun fallbackOnExternalTrainApiGet(
-        stationId: Long, subwayLineId: Long, e: RedisConnectionFailureException
+        stationId: Long, subwayLineId: Long, upDownType: UpDownType?, e: RedisConnectionFailureException
     ): List<GetTrainRealTimesDto.TrainRealTime> {
         logger.error("can't connect to redis server")
         throw CommonException(ResponseCode.FAILED_TO_CONNECT_TO_REDIS, e)
@@ -104,7 +104,7 @@ class TrainService(
      * 열차 도착 정보 API 오류에 대한 FallBack 메서드
      */
     fun fallbackOnExternalTrainApiGet(
-        stationId: Long, subwayLineId: Long, e : CallNotPermittedException
+        stationId: Long, subwayLineId: Long, upDownType: UpDownType?, e : CallNotPermittedException
     ): List<GetTrainRealTimesDto.TrainRealTime> {
         logger.error("circuit breaker opened for external train api")
         throw CommonException(ResponseCode.FAILED_TO_GET_TRAIN_INFO, e)

--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/train/application/service/TrainService.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/train/application/service/TrainService.kt
@@ -85,8 +85,8 @@ class TrainService(
 
         val trainRealTimes = trainRealTimeMap.getOrElse(subwayLineIdentity.toString()) { emptyList() }
 
-        return upDownType?.let { type ->
-            trainRealTimes.filter { it.upDownType == type }.take(4)
+        return upDownType?.let {
+                type ->  trainRealTimes.filter { it.upDownType == type }.take(4)
         } ?: trainRealTimes
     }
 
@@ -140,12 +140,16 @@ class TrainService(
         trainRealTime
             ?.groupBy { it.updnLine }
             ?.entries?.forEach { map ->
-                val lis = map.value.map { dto ->
-                    GetTrainRealTimesDto.TrainRealTime.of(dto, extractStationOrder(dto.arvlMsg2)) }
-                    .sortedWith( compareBy(
-                            { it.currentTrainArrivalCode.priority },
-                            { it.stationOrder }
-                    )).subList(0, 2)
+                val subIdx = if (map.value.size >= 2) 2 else 1  // 상행, 하행 각각 최대 두개씩 반환
+
+                val lis = map.value
+                    .map { dto ->
+                    GetTrainRealTimesDto.TrainRealTime.of(dto, extractStationOrder(dto.arvlMsg2))
+                    }.sortedWith( compareBy(
+                        { it.currentTrainArrivalCode.priority },
+                        { it.stationOrder }
+                    )).subList(0, subIdx)
+
                 total.addAll(lis)
             }
         return total


### PR DESCRIPTION
## 📚 개요
+ #342 

## ✏️ 작업 내용
+ 공공 API로부터 받은 값을 상행 | 하행으로 묶어 2개씩 자르는 로직에서, 반환값이 1개만 오는 경우에 대한 인덱스 에러를 해결했습니다.
  + 해당 부분 최대 2개까지 자를 수 있도록 핸들링 해주었습니다.

+ 서킷 브레이커 fallback 메서드를 찾지 못하는 이슈를 해결했습니다.
   + fallback 메서드는 메서드 파라미터 + 반환값이 원본 메서드와 같아야 하는데 파라미터 하나를 빼먹었던 것이 원인이였습니다.

## 💡 주의 사항
+ 없습니다 🙃
