### PR TITLE
:sparkles: 유실물 created_at 내림차순 인덱스 생성 (#338)

### DIFF
--- a/core/src/main/resources/db/migration/V20250222070500__add_lost_created_at_idx.sql
+++ b/core/src/main/resources/db/migration/V20250222070500__add_lost_created_at_idx.sql
@@ -1,0 +1,1 @@
+CREATE INDEX created_at_desc_idx ON tb_lost_post (created_at DESC);


### PR DESCRIPTION
## 📚 개요
+ #338
+ 연관 PR : https://github.com/ahachulTeam/ahhachul_backend/pull/227

## ✏️ 작업 내용
+ 분실물 조회 -> createdAt 기준 정렬, 습득물 조회 -> received_date 기준으로 정렬됩니다.
 + 현재 디벨롭에서 ddl-auto 설정이 꺼져있어 @Index 로 인덱스 생성이 되지 않습니다. 따라서 이전에 filesort를 방지하기 위한 received_date만 인덱스를 생성해두었는데, created_at를 깜빡해서 새로 내림차순 인덱스 생성했습니다.

## 💡 주의 사항
+ 없습니다 🙃