### PR TITLE
:recycle: 게시글 조회 시 즐겨찾는 역 배열로 받도록 수정 (#349)

### DIFF
--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/SearchCommunityHotPostDto.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/SearchCommunityHotPostDto.kt
@@ -6,7 +6,7 @@ import org.springframework.data.domain.Sort
 class SearchCommunityHotPostDto {
 
     data class Request(
-        val subwayLineId: Long?,
+        val subwayLineIds: String?,
         val content: String?,
         val hashTag: String?,
         val writer: String?,
@@ -14,7 +14,9 @@ class SearchCommunityHotPostDto {
     ) {
         fun toCommand(pageToken: String?, pageSize: Int): SearchCommunityHotPostCommand {
             return SearchCommunityHotPostCommand(
-                subwayLineId = subwayLineId,
+                subwayLineIds = subwayLineIds?.let {
+                    it.split(",").map { x -> x.toLong() }
+                },
                 content = content,
                 hashTag = hashTag,
                 writer = writer,

--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/SearchCommunityPostDto.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/dto/SearchCommunityPostDto.kt
@@ -10,7 +10,7 @@ class SearchCommunityPostDto {
 
     data class Request(
         val categoryType: CommunityCategoryType?,
-        val subwayLineId: Long?,
+        val subwayLineIds: String?,
         val content: String?,
         val hashTag: String?,
         val writer: String?,
@@ -19,7 +19,9 @@ class SearchCommunityPostDto {
         fun toCommand(pageToken: String?, pageSize: Int): SearchCommunityPostCommand {
             return SearchCommunityPostCommand(
                 categoryType = categoryType,
-                subwayLineId = subwayLineId,
+                subwayLineIds = subwayLineIds?.let {
+                    it.split(",").map { x -> x.toLong() }
+                },
                 content = content,
                 hashTag = hashTag,
                 writer = writer,

--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/community/application/service/CommunityPostService.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/community/application/service/CommunityPostService.kt
@@ -47,12 +47,14 @@ class CommunityPostService(
 
     override fun searchCommunityPosts(command: SearchCommunityPostCommand): PageInfoDto<SearchCommunityPostDto.Response> {
         val userId: String? = RequestUtils.getAttribute(RequestUtils.Attribute.MEMBER_ID)
-        val subwayLine = command.subwayLineId?.let { subwayLineReader.getById(it) }
+        val subwayLines = command.subwayLineIds?.stream()
+            ?.map { subwayLineReader.getById(it) }
+            ?.toList()
 
         val searchCommunityPosts = communityPostReader.searchCommunityPosts(
             GetSliceCommunityPostCommand.from(
                 command = command,
-                subwayLine = subwayLine
+                subwayLines = subwayLines
             )
         )
 
@@ -67,12 +69,14 @@ class CommunityPostService(
 
     override fun searchCommunityHotPosts(command: SearchCommunityHotPostCommand): PageInfoDto<SearchCommunityPostDto.Response> {
         val userId: String? = RequestUtils.getAttribute(RequestUtils.Attribute.MEMBER_ID)
-        val subwayLine = command.subwayLineId?.let { subwayLineReader.getById(it) }
+        val subwayLines = command.subwayLineIds?.stream()
+            ?.map { subwayLineReader.getById(it) }
+            ?.toList()
 
         val searchCommunityHotPosts = communityPostReader.searchCommunityHotPosts(
             GetSliceCommunityHotPostCommand.from(
                 command = command,
-                subwayLine = subwayLine
+                subwayLines = subwayLines
             )
         )
 

--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/complaint/adapter/web/in/dto/SearchComplaintPostDto.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/complaint/adapter/web/in/dto/SearchComplaintPostDto.kt
@@ -9,12 +9,14 @@ import backend.team.ahachul_backend.common.dto.ImageDto
 class SearchComplaintPostDto {
 
     data class Request(
-        val subwayLineId: Long?,
+        val subwayLineIds: String?,
         val keyword: String?,
     ) {
         fun toCommand(pageToken: String?, pageSize: Int): SearchComplaintPostCommand {
             return SearchComplaintPostCommand(
-                subwayLineId = subwayLineId,
+                subwayLineIds = subwayLineIds?.let {
+                    it.split(",").map { x -> x.toLong() }
+                },
                 keyword = keyword,
                 pageToken = pageToken,
                 pageSize = pageSize

--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/complaint/application/service/ComplaintPostService.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/complaint/application/service/ComplaintPostService.kt
@@ -38,12 +38,14 @@ class ComplaintPostService(
 ): ComplaintPostUseCase {
 
     override fun searchComplaintPosts(command: SearchComplaintPostCommand): PageInfoDto<SearchComplaintPostDto.Response> {
-        val subwayLine = command.subwayLineId?.let { subwayLineReader.getById(it) }
+        val subwayLines = command.subwayLineIds?.stream()
+            ?.map { subwayLineReader.getById(it) }
+            ?.toList()
 
         val complaintPosts = complaintPostReader.getComplaintPosts(
             GetSliceComplaintPostsCommand.of(
                 command = command,
-                subwayLine = subwayLine
+                subwayLines = subwayLines
             )
         ).map {
             val file = complaintPostFileReader.findByPostId(it.id)?.file

--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/lost/adapter/web/in/dto/SearchLostPostsDto.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/lost/adapter/web/in/dto/SearchLostPostsDto.kt
@@ -8,14 +8,16 @@ class SearchLostPostsDto {
 
     data class Request(
         val lostType: LostType,
-        val subwayLineIds: String,
+        val subwayLineIds: String?,
         val category: String?,
         val keyword: String?,
     ) {
         fun toCommand(pageToken: String?, pageSize: Int): SearchLostPostCommand {
             return SearchLostPostCommand(
                 lostType = lostType,
-                subwayLineIds = subwayLineIds.split(",").map { it.toLong() },
+                subwayLineIds = subwayLineIds?.let {
+                    it.split(",").map { x -> x.toLong() }
+                },
                 keyword = keyword,
                 category = category,
                 pageToken = pageToken,

--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/lost/adapter/web/in/dto/SearchLostPostsDto.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/lost/adapter/web/in/dto/SearchLostPostsDto.kt
@@ -8,14 +8,14 @@ class SearchLostPostsDto {
 
     data class Request(
         val lostType: LostType,
-        val subwayLineId: Long?,
+        val subwayLineIds: String,
         val category: String?,
         val keyword: String?,
     ) {
         fun toCommand(pageToken: String?, pageSize: Int): SearchLostPostCommand {
             return SearchLostPostCommand(
                 lostType = lostType,
-                subwayLineId = subwayLineId,
+                subwayLineIds = subwayLineIds.split(",").map { it.toLong() },
                 keyword = keyword,
                 category = category,
                 pageToken = pageToken,

--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/lost/application/service/LostPostService.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/lost/application/service/LostPostService.kt
@@ -110,12 +110,15 @@ class LostPostService(
     }
 
     override fun searchLostPosts(command: SearchLostPostCommand): PageInfoDto<SearchLostPostsDto.Response> {
-        val subwayLine = command.subwayLineId?.let { subwayLineReader.getById(it) }
+        val subwayLines = command.subwayLineIds.stream()
+            .map { subwayLineReader.getById(it) }
+            .toList()
+
         val category = command.category?.let { categoryReader.getCategoryByName(it) }
 
         val lostPostList = lostPostReader.getLostPosts(
             GetSliceLostPostsCommand.from(
-                command=command, subwayLine=subwayLine, category=category
+                command=command, subwayLines=subwayLines, category=category
             )
         )
 

--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/lost/application/service/LostPostService.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/lost/application/service/LostPostService.kt
@@ -110,9 +110,9 @@ class LostPostService(
     }
 
     override fun searchLostPosts(command: SearchLostPostCommand): PageInfoDto<SearchLostPostsDto.Response> {
-        val subwayLines = command.subwayLineIds.stream()
-            .map { subwayLineReader.getById(it) }
-            .toList()
+        val subwayLines = command.subwayLineIds?.stream()
+            ?.map { subwayLineReader.getById(it) }
+            ?.toList()
 
         val category = command.category?.let { categoryReader.getCategoryByName(it) }
 

--- a/application/src/test/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/CommunityPostControllerDocsTest.kt
+++ b/application/src/test/kotlin/backend/team/ahachul_backend/api/community/adapter/web/in/CommunityPostControllerDocsTest.kt
@@ -67,7 +67,7 @@ class CommunityPostControllerDocsTest : CommonDocsTestConfig() {
         val result = mockMvc.perform(
             get("/v1/community-posts")
                 .queryParam("categoryType", "ISSUE")
-                .queryParam("subwayLineId", "1")
+                .queryParam("subwayLineIds", "1,2")
                 .queryParam("content", "내용")
                 .queryParam("hashTag", "여행")
                 .queryParam("writer", "작성자")
@@ -87,7 +87,7 @@ class CommunityPostControllerDocsTest : CommonDocsTestConfig() {
                     getDocsResponse(),
                     queryParameters(
                         parameterWithName("categoryType").description("카테고리 타입").attributes(getFormatAttribute("FREE, INSIGHT, ISSUE, HUMOR")).optional(),
-                        parameterWithName("subwayLineId").description("노선 ID").optional(),
+                        parameterWithName("subwayLineIds").description("노선 ID 리스트").optional(),
                         parameterWithName("content").description("검색하고자 하는 내용").optional(),
                         parameterWithName("hashTag").description("검색하고자 하는 해시 태그").optional(),
                         parameterWithName("hotPostYn").description("검색하고자 하는 핫 게시글 여부").optional(),
@@ -153,7 +153,7 @@ class CommunityPostControllerDocsTest : CommonDocsTestConfig() {
         // when
         val result = mockMvc.perform(
             get("/v1/community-hot-posts")
-                .queryParam("subwayLineId", "1")
+                .queryParam("subwayLineIds", "1,2")
                 .queryParam("content", "내용")
                 .queryParam("hashTag", "여행")
                 .queryParam("writer", "작성자")
@@ -172,7 +172,7 @@ class CommunityPostControllerDocsTest : CommonDocsTestConfig() {
                     getDocsRequest(),
                     getDocsResponse(),
                     queryParameters(
-                        parameterWithName("subwayLineId").description("노선 ID").optional(),
+                        parameterWithName("subwayLineIds").description("노선 ID 리스트").optional(),
                         parameterWithName("content").description("검색하고자 하는 내용").optional(),
                         parameterWithName("hashTag").description("검색하고자 하는 해시 태그").optional(),
                         parameterWithName("writer").description("검색하고자 하는 작성자 닉네임").optional(),

--- a/application/src/test/kotlin/backend/team/ahachul_backend/api/community/application/service/CommunityPostServiceTest.kt
+++ b/application/src/test/kotlin/backend/team/ahachul_backend/api/community/application/service/CommunityPostServiceTest.kt
@@ -276,7 +276,7 @@ class CommunityPostServiceTest(
 
         val verifyNameCommand = SearchCommunityPostCommand(
             categoryType = null,
-            subwayLineId = null,
+            subwayLineIds = null,
             content = "제",
             hashTag = null,
             writer = null,
@@ -286,7 +286,7 @@ class CommunityPostServiceTest(
         )
         val verifyNameCommand2 = SearchCommunityPostCommand(
             categoryType = null,
-            subwayLineId = null,
+            subwayLineIds = null,
             content = "지하철",
             hashTag = null,
             writer = null,
@@ -296,7 +296,7 @@ class CommunityPostServiceTest(
         )
         val verifyNameCommand3 = SearchCommunityPostCommand(
             categoryType = null,
-            subwayLineId = null,
+            subwayLineIds = null,
             content = "지하철",
             hashTag = null,
             writer = null,
@@ -306,7 +306,7 @@ class CommunityPostServiceTest(
         )
         val verifyOrderCommand = SearchCommunityPostCommand(
             categoryType = null,
-            subwayLineId = null,
+            subwayLineIds = null,
             content = null,
             hashTag = null,
             writer = null,
@@ -359,7 +359,7 @@ class CommunityPostServiceTest(
 
          val verifyCategoryCommand = SearchCommunityPostCommand(
              categoryType = CommunityCategoryType.FREE,
-             subwayLineId = null,
+             subwayLineIds = null,
              content = null,
              hashTag = null,
              writer = null,
@@ -369,7 +369,7 @@ class CommunityPostServiceTest(
          )
          val verifyCategoryCommand2 = SearchCommunityPostCommand(
              categoryType = CommunityCategoryType.ISSUE,
-             subwayLineId = null,
+             subwayLineIds = null,
              content = null,
              hashTag = null,
              writer = null,
@@ -411,7 +411,7 @@ class CommunityPostServiceTest(
 
         val verifyHashTagCommand = SearchCommunityPostCommand(
             categoryType = null,
-            subwayLineId = null,
+            subwayLineIds = null,
             content = null,
             hashTag = "여행",
             writer = null,
@@ -421,7 +421,7 @@ class CommunityPostServiceTest(
         )
         val verifyHashTagCommand2 = SearchCommunityPostCommand(
             categoryType = null,
-            subwayLineId = null,
+            subwayLineIds = null,
             content = null,
             hashTag = "취미",
             writer = null,
@@ -461,7 +461,7 @@ class CommunityPostServiceTest(
 
         val verifyWriterCommand = SearchCommunityPostCommand(
             categoryType = null,
-            subwayLineId = null,
+            subwayLineIds = null,
             content = null,
             hashTag = null,
             writer = "nickname",
@@ -493,7 +493,7 @@ class CommunityPostServiceTest(
         // when
         val searchCommand1 = SearchCommunityPostCommand(
             categoryType = null,
-            subwayLineId = null,
+            subwayLineIds = listOf(subwayLine.id),
             content = null,
             hashTag = null,
             writer = null,
@@ -506,7 +506,7 @@ class CommunityPostServiceTest(
 
         val searchCommand2 = SearchCommunityPostCommand(
             categoryType = null,
-            subwayLineId = null,
+            subwayLineIds = listOf(subwayLine.id),
             content = null,
             hashTag = null,
             writer = null,
@@ -556,7 +556,7 @@ class CommunityPostServiceTest(
 
         val result = communityPostUseCase.searchCommunityHotPosts(
             SearchCommunityHotPostCommand(
-                subwayLineId = null,
+                subwayLineIds = listOf(subwayLine.id),
                 content = null,
                 hashTag = null,
                 writer = null,

--- a/application/src/test/kotlin/backend/team/ahachul_backend/api/complaint/adapter/web/in/ComplaintPostControllerDocsTest.kt
+++ b/application/src/test/kotlin/backend/team/ahachul_backend/api/complaint/adapter/web/in/ComplaintPostControllerDocsTest.kt
@@ -80,7 +80,7 @@ class ComplaintPostControllerDocsTest : CommonDocsTestConfig() {
                     getDocsRequest(),
                     getDocsResponse(),
                     queryParameters(
-                        parameterWithName("subwayLineId2").description("민원 호선 리스트").optional(),
+                        parameterWithName("subwayLineIds").description("민원 호선 리스트").optional(),
                         parameterWithName("keyword").description("검색 키워드 명칭").optional(),
                         parameterWithName("pageToken").description("base64로 인코딩 된 페이지 토큰 문자열").optional(),
                         parameterWithName("pageSize").description("페이지 노출 데이터 수. index 0부터 시작"),

--- a/application/src/test/kotlin/backend/team/ahachul_backend/api/complaint/adapter/web/in/ComplaintPostControllerDocsTest.kt
+++ b/application/src/test/kotlin/backend/team/ahachul_backend/api/complaint/adapter/web/in/ComplaintPostControllerDocsTest.kt
@@ -65,7 +65,7 @@ class ComplaintPostControllerDocsTest : CommonDocsTestConfig() {
         // when
         val result = mockMvc.perform(
             get("/v1/complaint-posts")
-                .queryParam("subwayLineId", "1")
+                .queryParam("subwayLineIds", "1,2")
                 .queryParam("keyword", "검색 키워드 이름")
                 .queryParam("pageToken", "MTIzMTI5MTU6MTI=")
                 .queryParam("pageSize", "10")
@@ -80,7 +80,7 @@ class ComplaintPostControllerDocsTest : CommonDocsTestConfig() {
                     getDocsRequest(),
                     getDocsResponse(),
                     queryParameters(
-                        parameterWithName("subwayLineId").description("민원 호선").optional(),
+                        parameterWithName("subwayLineId2").description("민원 호선 리스트").optional(),
                         parameterWithName("keyword").description("검색 키워드 명칭").optional(),
                         parameterWithName("pageToken").description("base64로 인코딩 된 페이지 토큰 문자열").optional(),
                         parameterWithName("pageSize").description("페이지 노출 데이터 수. index 0부터 시작"),

--- a/application/src/test/kotlin/backend/team/ahachul_backend/api/complaint/application/service/ComplaintPostServiceTest.kt
+++ b/application/src/test/kotlin/backend/team/ahachul_backend/api/complaint/application/service/ComplaintPostServiceTest.kt
@@ -34,6 +34,7 @@ class ComplaintPostServiceTest(
 
     lateinit var member: MemberEntity
     lateinit var subwayLine: SubwayLineEntity
+    lateinit var subwayLine2: SubwayLineEntity
 
     @BeforeEach
     fun setUp() {
@@ -52,6 +53,12 @@ class ComplaintPostServiceTest(
         subwayLine = subwayLineRepository.save(
             SubwayLineEntity(
                 name = "1호선",
+                regionType = RegionType.METROPOLITAN
+            )
+        )
+        subwayLine2 = subwayLineRepository.save(
+            SubwayLineEntity(
+                name = "2호선",
                 regionType = RegionType.METROPOLITAN
             )
         )
@@ -76,7 +83,7 @@ class ComplaintPostServiceTest(
 
         // when
         val searchComplaintPostCommand = SearchComplaintPostCommand(
-            subwayLineId = subwayLine.id,
+            subwayLineIds = listOf(subwayLine.id),
             keyword = null,
             pageToken = null,
             pageSize = 10
@@ -121,7 +128,7 @@ class ComplaintPostServiceTest(
 
         // when
         val searchComplaintPostCommand = SearchComplaintPostCommand(
-            subwayLineId = null,
+            subwayLineIds = listOf(subwayLine.id),
             keyword = "용",
             pageToken = null,
             pageSize = 10
@@ -132,6 +139,53 @@ class ComplaintPostServiceTest(
         assertThat(searchComplaintPosts.data).hasSize(1)
         assertThat(searchComplaintPosts.data[0].id).isEqualTo(complaintPost1.id)
         assertThat(searchComplaintPosts.data[0].content).isEqualTo(complaintPost1.content)
+    }
+
+    @Test
+    fun 민원_조회_즐겨찾는_역() {
+        // given
+        val createComplaintPostCommand1 = CreateComplaintPostCommand(
+            complaintType = ComplaintType.ENVIRONMENTAL_COMPLAINT,
+            shortContentType = ShortContentType.SELF,
+            content = "내용",
+            phoneNumber = null,
+            trainNo = null,
+            location = null,
+            subwayLineId = subwayLine.id,
+            imageFiles = listOf(),
+        )
+
+        val createComplaintPostCommand2 = CreateComplaintPostCommand(
+            complaintType = ComplaintType.ENVIRONMENTAL_COMPLAINT,
+            shortContentType = ShortContentType.SELF,
+            content = "123",
+            phoneNumber = null,
+            trainNo = null,
+            location = null,
+            subwayLineId = subwayLine2.id,
+            imageFiles = listOf(),
+        )
+
+        val complaintPost1 = ComplaintPostEntity.of(createComplaintPostCommand1, member, subwayLine)
+        val complaintPost2 = ComplaintPostEntity.of(createComplaintPostCommand2, member, subwayLine2)
+        complaintPostRepository.save(complaintPost1)
+        complaintPostRepository.save(complaintPost2)
+
+        // when
+        val searchComplaintPostCommand = SearchComplaintPostCommand(
+            subwayLineIds = listOf(subwayLine.id, subwayLine2.id),
+            keyword = null,
+            pageToken = null,
+            pageSize = 10
+        )
+        val searchComplaintPosts = complaintPostUseCase.searchComplaintPosts(searchComplaintPostCommand)
+
+        // then
+        assertThat(searchComplaintPosts.data).hasSize(2)
+        assertThat(searchComplaintPosts.data[0].id).isEqualTo(complaintPost2.id)
+        assertThat(searchComplaintPosts.data[0].content).isEqualTo(complaintPost2.content)
+        assertThat(searchComplaintPosts.data[1].id).isEqualTo(complaintPost1.id)
+        assertThat(searchComplaintPosts.data[1].content).isEqualTo(complaintPost1.content)
     }
 
     @Test

--- a/application/src/test/kotlin/backend/team/ahachul_backend/api/lost/adapter/web/in/LostPostControllerDocsTest.kt
+++ b/application/src/test/kotlin/backend/team/ahachul_backend/api/lost/adapter/web/in/LostPostControllerDocsTest.kt
@@ -136,7 +136,7 @@ class LostPostControllerDocsTest: CommonDocsTestConfig() {
         val result = mockMvc.perform(
             get("/v1/lost-posts")
                 .queryParam("lostType", LostType.LOST.name)
-                .queryParam("subwayLineId", "1")
+                .queryParam("subwayLineIds", "1,2")
                 .queryParam("keyword", "검색 키워드 이름")
                 .queryParam("pageToken", "MTIzMTI5MTU6MTI=")
                 .queryParam("pageSize", "10" )
@@ -150,7 +150,7 @@ class LostPostControllerDocsTest: CommonDocsTestConfig() {
                 getDocsResponse(),
                 queryParameters(
                     parameterWithName("lostType").description("유실물 카테고리").attributes(getFormatAttribute("LOST(유실물) / ACQUIRE(습득물 + Lost112)")),
-                    parameterWithName("subwayLineId").description("유실물 호선").optional(),
+                    parameterWithName("subwayLineIds").description("유실물 호선 리스트").optional(),
                     parameterWithName("keyword").description("검색 키워드 명칭").optional(),
                     parameterWithName("pageToken").description("base64로 인코딩 된 페이지 토큰 문자열").optional(),
                     parameterWithName("pageSize").description("페이지 노출 데이터 수. index 0부터 시작"),

--- a/application/src/test/kotlin/backend/team/ahachul_backend/api/lost/application/service/LostPostServiceTest.kt
+++ b/application/src/test/kotlin/backend/team/ahachul_backend/api/lost/application/service/LostPostServiceTest.kt
@@ -395,7 +395,7 @@ class LostPostServiceTest(
     private fun createSearchLostPostCommand(pageToken: String?, subwayLineId:Long, keyword:String?): SearchLostPostCommand {
         return SearchLostPostCommand(
             lostType = LostType.ACQUIRE,
-            subwayLineId = subwayLineId,
+            subwayLineIds = listOf(subwayLineId),
             keyword = keyword,
             category = "휴대폰",
             pageToken = pageToken,

--- a/core/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/out/CustomCommunityPostRepository.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/api/community/adapter/web/out/CustomCommunityPostRepository.kt
@@ -9,6 +9,8 @@ import backend.team.ahachul_backend.api.community.domain.entity.QCommunityPostEn
 import backend.team.ahachul_backend.api.community.domain.entity.QCommunityPostHashTagEntity.communityPostHashTagEntity
 import backend.team.ahachul_backend.api.community.domain.entity.QCommunityPostLikeEntity.communityPostLikeEntity
 import backend.team.ahachul_backend.api.community.domain.model.CommunityCategoryType
+import backend.team.ahachul_backend.api.lost.domain.entity.QLostPostEntity
+import backend.team.ahachul_backend.api.lost.domain.entity.QLostPostEntity.lostPostEntity
 import backend.team.ahachul_backend.api.member.domain.entity.QMemberEntity.memberEntity
 import backend.team.ahachul_backend.common.domain.entity.QHashTagEntity.hashTagEntity
 import backend.team.ahachul_backend.common.domain.entity.QSubwayLineEntity.subwayLineEntity
@@ -116,7 +118,7 @@ class CustomCommunityPostRepository(
             .join(communityPostEntity.subwayLineEntity, subwayLineEntity)
             .where(
                 categoryTypeEq(command.categoryType),
-                subwayLineEq(command.subwayLine),
+                subwayLinesEq(command.subwayLines),
                 hashTagEqWithSubQuery(command.hashTag),
                 titleOrContentContains(command.content),
                 writerEq(command.writer),
@@ -139,7 +141,7 @@ class CustomCommunityPostRepository(
             .join(communityPostEntity.subwayLineEntity, subwayLineEntity)
             .where(
                 hotPost(),
-                subwayLineEq(command.subwayLine),
+                subwayLinesEq(command.subwayLines),
                 hashTagEqWithSubQuery(command.hashTag),
                 titleOrContentContains(command.content),
                 writerEq(command.writer),
@@ -172,6 +174,10 @@ class CustomCommunityPostRepository(
 
     private fun subwayLineEq(subwayLine: SubwayLineEntity?) =
         subwayLine?.let { communityPostEntity.subwayLineEntity.eq(subwayLine) }
+
+    private fun subwayLinesEq(subwayLines: List<SubwayLineEntity>?) =
+        subwayLines?.takeIf { it.isNotEmpty() }
+            ?.let { communityPostEntity.subwayLineEntity.`in`(it) }
 
     private fun hotPost() = communityPostEntity.hotPostYn.eq(YNType.Y)
         .and(communityPostEntity.hotPostSelectedDate.after(LocalDateTime.now().minusDays(HOT_POST_LIMIT_DAYS)))

--- a/core/src/main/kotlin/backend/team/ahachul_backend/api/community/application/command/in/SearchCommunityHotPostCommand.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/api/community/application/command/in/SearchCommunityHotPostCommand.kt
@@ -3,7 +3,7 @@ package backend.team.ahachul_backend.api.community.application.command.`in`
 import org.springframework.data.domain.Sort
 
 class SearchCommunityHotPostCommand(
-    val subwayLineId: Long?,
+    val subwayLineIds: List<Long>?,
     val content: String?,
     val hashTag: String?,
     val writer: String?,

--- a/core/src/main/kotlin/backend/team/ahachul_backend/api/community/application/command/in/SearchCommunityPostCommand.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/api/community/application/command/in/SearchCommunityPostCommand.kt
@@ -5,7 +5,7 @@ import org.springframework.data.domain.Sort
 
 class SearchCommunityPostCommand(
     val categoryType: CommunityCategoryType?,
-    val subwayLineId: Long?,
+    val subwayLineIds: List<Long>?,
     val content: String?,
     val hashTag: String?,
     val writer: String?,

--- a/core/src/main/kotlin/backend/team/ahachul_backend/api/community/application/command/out/GetSliceCommunityHotPostCommand.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/api/community/application/command/out/GetSliceCommunityHotPostCommand.kt
@@ -7,7 +7,7 @@ import org.springframework.data.domain.Sort
 import java.time.LocalDateTime
 
 class GetSliceCommunityHotPostCommand(
-    val subwayLine: SubwayLineEntity?,
+    val subwayLines: List<SubwayLineEntity>?,
     val content: String?,
     val hashTag: String?,
     val writer: String?,
@@ -19,14 +19,14 @@ class GetSliceCommunityHotPostCommand(
     companion object {
         fun from(
             command: SearchCommunityHotPostCommand,
-            subwayLine: SubwayLineEntity?,
+            subwayLines: List<SubwayLineEntity>?,
         ): GetSliceCommunityHotPostCommand {
             val pageToken = command.pageToken?.let {
                 PageTokenUtils.decodePageToken(it, listOf(LocalDateTime::class.java, Long::class.java))
             }
 
             return GetSliceCommunityHotPostCommand(
-                subwayLine = subwayLine,
+                subwayLines = subwayLines,
                 content = command.content,
                 hashTag = command.hashTag,
                 writer = command.writer,

--- a/core/src/main/kotlin/backend/team/ahachul_backend/api/community/application/command/out/GetSliceCommunityPostCommand.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/api/community/application/command/out/GetSliceCommunityPostCommand.kt
@@ -9,7 +9,7 @@ import java.time.LocalDateTime
 
 class GetSliceCommunityPostCommand(
     val categoryType: CommunityCategoryType?,
-    val subwayLine: SubwayLineEntity?,
+    val subwayLines: List<SubwayLineEntity>?,
     val content: String?,
     val hashTag: String?,
     val writer: String?,
@@ -21,7 +21,7 @@ class GetSliceCommunityPostCommand(
     companion object {
         fun from(
             command: SearchCommunityPostCommand,
-            subwayLine: SubwayLineEntity?,
+            subwayLines: List<SubwayLineEntity>?,
         ): GetSliceCommunityPostCommand {
             val pageToken = command.pageToken?.let {
                 PageTokenUtils.decodePageToken(it, listOf(LocalDateTime::class.java, Long::class.java))
@@ -29,7 +29,7 @@ class GetSliceCommunityPostCommand(
 
             return GetSliceCommunityPostCommand(
                 categoryType = command.categoryType,
-                subwayLine = subwayLine,
+                subwayLines = subwayLines,
                 content = command.content,
                 hashTag = command.hashTag,
                 writer = command.writer,

--- a/core/src/main/kotlin/backend/team/ahachul_backend/api/complaint/adapter/out/CustomComplaintPostRepository.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/api/complaint/adapter/out/CustomComplaintPostRepository.kt
@@ -20,7 +20,7 @@ class CustomComplaintPostRepository(
         return queryFactory
             .selectFrom(complaintPostEntity)
             .where(
-                subwayLineEq(command.subwayLine),
+                subwayLinesEq(command.subwayLines),
                 contentLike(command.keyword),
                 createdAtBeforeOrEqual(
                     command.date,
@@ -35,6 +35,10 @@ class CustomComplaintPostRepository(
 
     private fun subwayLineEq(subwayLine: SubwayLineEntity?) =
         subwayLine?.let { complaintPostEntity.subwayLine.eq(subwayLine) }
+
+    private fun subwayLinesEq(subwayLines: List<SubwayLineEntity>?) =
+        subwayLines?.takeIf { it.isNotEmpty() }
+            ?.let { complaintPostEntity.subwayLine.`in`(it) }
 
     private fun contentLike(keyword: String?) =
         keyword?.let { complaintPostEntity.content.contains(keyword) }

--- a/core/src/main/kotlin/backend/team/ahachul_backend/api/complaint/application/command/in/SearchComplaintPostCommand.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/api/complaint/application/command/in/SearchComplaintPostCommand.kt
@@ -1,7 +1,7 @@
 package backend.team.ahachul_backend.api.complaint.application.command.`in`
 
 class SearchComplaintPostCommand(
-    val subwayLineId: Long?,
+    val subwayLineIds: List<Long>?,
     val keyword: String?,
     val pageToken: String?,
     val pageSize: Int

--- a/core/src/main/kotlin/backend/team/ahachul_backend/api/complaint/application/command/out/GetSliceComplaintPostsCommand.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/api/complaint/application/command/out/GetSliceComplaintPostsCommand.kt
@@ -7,20 +7,20 @@ import java.time.LocalDateTime
 
 class GetSliceComplaintPostsCommand(
     val keyword: String?,
-    val subwayLine: SubwayLineEntity?,
+    val subwayLines: List<SubwayLineEntity>?,
     val date: LocalDateTime?,
     val complaintPostId: Long?,
     val pageSize : Int,
 ) {
     companion object {
-        fun of(command: SearchComplaintPostCommand, subwayLine: SubwayLineEntity?): GetSliceComplaintPostsCommand {
+        fun of(command: SearchComplaintPostCommand, subwayLines: List<SubwayLineEntity>?): GetSliceComplaintPostsCommand {
             val pageToken = command.pageToken?.let {
                 PageTokenUtils.decodePageToken(it, listOf(LocalDateTime::class.java, Long::class.java))
             }
 
             return GetSliceComplaintPostsCommand(
                 keyword = command.keyword,
-                subwayLine = subwayLine,
+                subwayLines = subwayLines,
                 date = pageToken?.get(0) as LocalDateTime?,
                 complaintPostId = pageToken?.get(1) as Long?,
                 pageSize = command.pageSize,

--- a/core/src/main/kotlin/backend/team/ahachul_backend/api/lost/adapter/web/out/CustomLostPostRepository.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/api/lost/adapter/web/out/CustomLostPostRepository.kt
@@ -69,7 +69,7 @@ class CustomLostPostRepository(
 
         return queryFactory.selectFrom(lostPostEntity)
             .where(
-                subwayLineEq(command.subwayLine),
+                subwayLinesEq(command.subwayLines),
                 lostTypeEq(command.lostType),
                 categoryEq(command.category),
                 titleAndContentLike(command.keyword),
@@ -111,6 +111,10 @@ class CustomLostPostRepository(
 
     private fun subwayLineEq(subwayLine: SubwayLineEntity?) =
         subwayLine?.let { lostPostEntity.subwayLine.eq(subwayLine) }
+
+    private fun subwayLinesEq(subwayLines: List<SubwayLineEntity>?) =
+        subwayLines?.takeIf { it.isNotEmpty() }
+            ?.let { lostPostEntity.subwayLine.`in`(it) }
 
     private fun lostTypeEq(lostType: LostType?) =
         lostType?.let { lostPostEntity.lostType.eq(lostType) }

--- a/core/src/main/kotlin/backend/team/ahachul_backend/api/lost/application/command/in/SearchLostPostCommand.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/api/lost/application/command/in/SearchLostPostCommand.kt
@@ -4,7 +4,7 @@ import backend.team.ahachul_backend.api.lost.domain.model.LostType
 
 class SearchLostPostCommand(
     val lostType: LostType,
-    val subwayLineIds: List<Long>,
+    val subwayLineIds: List<Long>?,
     val category: String?,
     val keyword: String?,
     val pageToken: String?,

--- a/core/src/main/kotlin/backend/team/ahachul_backend/api/lost/application/command/in/SearchLostPostCommand.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/api/lost/application/command/in/SearchLostPostCommand.kt
@@ -4,7 +4,7 @@ import backend.team.ahachul_backend.api.lost.domain.model.LostType
 
 class SearchLostPostCommand(
     val lostType: LostType,
-    val subwayLineId: Long?,
+    val subwayLineIds: List<Long>,
     val category: String?,
     val keyword: String?,
     val pageToken: String?,

--- a/core/src/main/kotlin/backend/team/ahachul_backend/api/lost/application/command/out/GetSliceLostPostsCommand.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/api/lost/application/command/out/GetSliceLostPostsCommand.kt
@@ -9,7 +9,7 @@ import java.time.LocalDateTime
 
 class GetSliceLostPostsCommand(
     val lostType: LostType,
-    val subwayLines: List<SubwayLineEntity>,
+    val subwayLines: List<SubwayLineEntity>?,
     val category: CategoryEntity?,
     val keyword: String?,
     val date: LocalDateTime?,
@@ -18,7 +18,7 @@ class GetSliceLostPostsCommand(
 ) {
     companion object {
         fun from(
-            command: SearchLostPostCommand, subwayLines: List<SubwayLineEntity>, category: CategoryEntity?
+            command: SearchLostPostCommand, subwayLines: List<SubwayLineEntity>?, category: CategoryEntity?
         ): GetSliceLostPostsCommand {
             val pageToken = command.pageToken?.let {
                 PageTokenUtils.decodePageToken(it, listOf(LocalDateTime::class.java, Long::class.java))

--- a/core/src/main/kotlin/backend/team/ahachul_backend/api/lost/application/command/out/GetSliceLostPostsCommand.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/api/lost/application/command/out/GetSliceLostPostsCommand.kt
@@ -9,7 +9,7 @@ import java.time.LocalDateTime
 
 class GetSliceLostPostsCommand(
     val lostType: LostType,
-    val subwayLine: SubwayLineEntity?,
+    val subwayLines: List<SubwayLineEntity>,
     val category: CategoryEntity?,
     val keyword: String?,
     val date: LocalDateTime?,
@@ -18,7 +18,7 @@ class GetSliceLostPostsCommand(
 ) {
     companion object {
         fun from(
-            command: SearchLostPostCommand, subwayLine: SubwayLineEntity?, category: CategoryEntity?
+            command: SearchLostPostCommand, subwayLines: List<SubwayLineEntity>, category: CategoryEntity?
         ): GetSliceLostPostsCommand {
             val pageToken = command.pageToken?.let {
                 PageTokenUtils.decodePageToken(it, listOf(LocalDateTime::class.java, Long::class.java))
@@ -26,7 +26,7 @@ class GetSliceLostPostsCommand(
 
             return GetSliceLostPostsCommand(
                 lostType = command.lostType,
-                subwayLine = subwayLine,
+                subwayLines = subwayLines,
                 category = category,
                 keyword = command.keyword,
                 date = pageToken?.get(0) as LocalDateTime?,


### PR DESCRIPTION
## 📚 개요
+ #349 

## ✏️ 작업 내용
+ 커뮤니티 / 민원 / 유실물 탭 내 호선만 보기 기능에서 여러 개의 역이 조회될 수 있도록 수정했습니다.

<img width="528" alt="image" src="https://github.com/user-attachments/assets/5e628a00-966e-42b8-ae46-a265c3f64a01" />


## 💡 주의 사항
+ 인기 게시글도 혹시 몰라서 같이 수정해놨습니다.
+ 변경 사항이 많아서 코멘트 단 곳 위주로 봐주시면 될 것 같아요.
