### PR TITLE
:sparkles: 회원 탈퇴 기능 구현 (#359)

### DIFF
--- a/.github/workflows/dev-api-deploy.yml
+++ b/.github/workflows/dev-api-deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - develop
-      - feature/359
     paths-ignore:
       - 'scheduler/**'
       - '.github/**'
@@ -12,12 +11,6 @@ on:
 
 jobs:
   build:
-    if: |
-      contains(join(github.event.commits.*.modified, ','), 'application/') || 
-      (contains(join(github.event.commits.*.modified, ','), 'core/') && !contains(join(github.event.commits.*.modified, ','), 'scheduler/'))
-#    if: |
-#      contains(github.event.commits.*.modified, 'application/') ||
-#      (contains(github.event.commits.*.modified, 'core/') && !contains(github.event.commits.*.modified, 'scheduler/'))
     runs-on: ubuntu-latest
     env:
       MODULE_NAME: application

--- a/.github/workflows/dev-api-deploy.yml
+++ b/.github/workflows/dev-api-deploy.yml
@@ -7,13 +7,17 @@ on:
       - feature/359
     paths-ignore:
       - 'scheduler/**'
+      - '.github/**'
   workflow_dispatch:
 
 jobs:
   build:
     if: |
-      contains(github.event.commits.*.modified, 'application/') ||
-      (contains(github.event.commits.*.modified, 'core/') && !contains(github.event.commits.*.modified, 'scheduler/'))
+      contains(join(github.event.commits.*.modified, ','), 'application/') || 
+      (contains(join(github.event.commits.*.modified, ','), 'core/') && !contains(join(github.event.commits.*.modified, ','), 'scheduler/'))
+#    if: |
+#      contains(github.event.commits.*.modified, 'application/') ||
+#      (contains(github.event.commits.*.modified, 'core/') && !contains(github.event.commits.*.modified, 'scheduler/'))
     runs-on: ubuntu-latest
     env:
       MODULE_NAME: application

--- a/.github/workflows/dev-api-deploy.yml
+++ b/.github/workflows/dev-api-deploy.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - develop
+      - feature/359
+    paths:
+      - 'application/**'
+      - 'core/**'
     paths-ignore:
       - 'scheduler/**'
       - '.github/**'
@@ -11,9 +15,9 @@ on:
 
 jobs:
   build:
-    if: |
-      contains(github.event.commits.*.modified, 'application/') || 
-      (contains(github.event.commits.*.modified, 'core/') && !contains(github.event.commits.*.modified, 'scheduler/'))
+#    if: |
+#      contains(github.event.commits.*.modified, 'application/') ||
+#      (contains(github.event.commits.*.modified, 'core/') && !contains(github.event.commits.*.modified, 'scheduler/'))
     runs-on: ubuntu-latest
     env:
       MODULE_NAME: application

--- a/.github/workflows/dev-api-deploy.yml
+++ b/.github/workflows/dev-api-deploy.yml
@@ -7,7 +7,6 @@ on:
       - feature/359
     paths-ignore:
       - 'scheduler/**'
-      - '.github/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/dev-api-deploy.yml
+++ b/.github/workflows/dev-api-deploy.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - develop
       - feature/359
-    paths:
-      - 'application/**'
-      - 'core/**'
     paths-ignore:
       - 'scheduler/**'
       - '.github/**'
@@ -15,9 +12,9 @@ on:
 
 jobs:
   build:
-#    if: |
-#      contains(github.event.commits.*.modified, 'application/') ||
-#      (contains(github.event.commits.*.modified, 'core/') && !contains(github.event.commits.*.modified, 'scheduler/'))
+    if: |
+      contains(github.event.commits.*.modified, 'application/') ||
+      (contains(github.event.commits.*.modified, 'core/') && !contains(github.event.commits.*.modified, 'scheduler/'))
     runs-on: ubuntu-latest
     env:
       MODULE_NAME: application

--- a/.github/workflows/dev-batch-deploy.yml
+++ b/.github/workflows/dev-batch-deploy.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - develop
+      - feature/359
+    paths:
+      - 'scheduler/**'
+      - 'core/**'
     paths-ignore:
       - 'application/**'
       - '.github/**'
@@ -12,9 +16,9 @@ on:
 
 jobs:
   build:
-    if: |
-      contains(github.event.commits.*.modified, 'scheduler/') || 
-      (contains(github.event.commits.*.modified, 'core/') && !contains(github.event.commits.*.modified, 'application/'))
+#    if: |
+#      contains(github.event.commits.*.modified, 'scheduler/') ||
+#      (contains(github.event.commits.*.modified, 'core/') && !contains(github.event.commits.*.modified, 'application/'))
     runs-on: ubuntu-latest
     env:
       MODULE_NAME: scheduler

--- a/.github/workflows/dev-batch-deploy.yml
+++ b/.github/workflows/dev-batch-deploy.yml
@@ -7,7 +7,6 @@ on:
       - feature/359
     paths-ignore:
       - 'application/**'
-      - '.github/**'
       - 'scheduler/cron.Dockerfile'
   workflow_dispatch:
 

--- a/.github/workflows/dev-batch-deploy.yml
+++ b/.github/workflows/dev-batch-deploy.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - develop
       - feature/359
-    paths:
-      - 'scheduler/**'
-      - 'core/**'
     paths-ignore:
       - 'application/**'
       - '.github/**'
@@ -16,9 +13,9 @@ on:
 
 jobs:
   build:
-#    if: |
-#      contains(github.event.commits.*.modified, 'scheduler/') ||
-#      (contains(github.event.commits.*.modified, 'core/') && !contains(github.event.commits.*.modified, 'application/'))
+    if: |
+      contains(github.event.commits.*.modified, 'scheduler/') || 
+      (contains(github.event.commits.*.modified, 'core/') && !contains(github.event.commits.*.modified, 'application/'))
     runs-on: ubuntu-latest
     env:
       MODULE_NAME: scheduler

--- a/.github/workflows/dev-batch-deploy.yml
+++ b/.github/workflows/dev-batch-deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - develop
-      - feature/359
     paths-ignore:
       - 'application/**'
       - '.github/**'
@@ -13,12 +12,6 @@ on:
 
 jobs:
   build:
-    if: |
-      contains(join(github.event.commits.*.modified, ','), 'scheduler/') || 
-      (contains(join(github.event.commits.*.modified, ','), 'core/') && !contains(join(github.event.commits.*.modified, ','), 'application/'))
-#    if: |
-#      contains(github.event.commits.*.modified, 'scheduler/') ||
-#      (contains(github.event.commits.*.modified, 'core/') && !contains(github.event.commits.*.modified, 'application/'))
     runs-on: ubuntu-latest
     env:
       MODULE_NAME: scheduler

--- a/.github/workflows/dev-batch-deploy.yml
+++ b/.github/workflows/dev-batch-deploy.yml
@@ -7,14 +7,18 @@ on:
       - feature/359
     paths-ignore:
       - 'application/**'
+      - '.github/**'
       - 'scheduler/cron.Dockerfile'
   workflow_dispatch:
 
 jobs:
   build:
     if: |
-      contains(github.event.commits.*.modified, 'scheduler/') || 
-      (contains(github.event.commits.*.modified, 'core/') && !contains(github.event.commits.*.modified, 'application/'))
+      contains(join(github.event.commits.*.modified, ','), 'scheduler/') || 
+      (contains(join(github.event.commits.*.modified, ','), 'core/') && !contains(join(github.event.commits.*.modified, ','), 'application/'))
+#    if: |
+#      contains(github.event.commits.*.modified, 'scheduler/') ||
+#      (contains(github.event.commits.*.modified, 'core/') && !contains(github.event.commits.*.modified, 'application/'))
     runs-on: ubuntu-latest
     env:
       MODULE_NAME: scheduler

--- a/application/src/docs/asciidoc/member/members.adoc
+++ b/application/src/docs/asciidoc/member/members.adoc
@@ -24,6 +24,17 @@ include::{snippets}/update-member/http-response.adoc[]
 .Response Fields
 include::{snippets}/update-member/response-fields.adoc[]
 
+==== 사용자 탈퇴
+
+.Request
+include::{snippets}/delete-member/http-request.adoc[]
+.Request Headers
+include::{snippets}/delete-member/request-headers.adoc[]
+.Response
+include::{snippets}/delete-member/http-response.adoc[]
+.Response Fields
+include::{snippets}/delete-member/response-fields.adoc[]
+
 ==== 사용자 닉네임 중복 체크
 
 .Request

--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/MemberController.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/MemberController.kt
@@ -4,16 +4,11 @@ import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.*
 import backend.team.ahachul_backend.api.member.application.port.`in`.MemberUseCase
 import backend.team.ahachul_backend.common.annotation.Authentication
 import backend.team.ahachul_backend.common.response.CommonResponse
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PatchMapping
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.PutMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 class MemberController(
-        private val memberUseCase: MemberUseCase
+    private val memberUseCase: MemberUseCase
 ) {
 
     @Authentication
@@ -25,14 +20,21 @@ class MemberController(
     @Authentication
     @PatchMapping("/v1/members")
     fun updateMember(
-            @RequestBody request: UpdateMemberDto.Request
+        @RequestBody request: UpdateMemberDto.Request
     ): CommonResponse<UpdateMemberDto.Response> {
         return CommonResponse.success(memberUseCase.updateMember(request.toCommand()))
     }
 
+    @Authentication
+    @DeleteMapping("/v1/members")
+    fun deleteMember(@RequestHeader("Authorization") authorizationHeader: String): CommonResponse<*> {
+        memberUseCase.deleteMember(DeleteMemberDto.Request(authorizationHeader))
+        return CommonResponse.success()
+    }
+
     @PostMapping("/v1/members/check-nickname")
     fun checkNickname(
-            @RequestBody request: CheckNicknameDto.Request
+        @RequestBody request: CheckNicknameDto.Request
     ): CommonResponse<CheckNicknameDto.Response> {
         return CommonResponse.success(memberUseCase.checkNickname(request.toCommand()))
     }
@@ -40,7 +42,7 @@ class MemberController(
     @Authentication
     @PostMapping("/v1/members/bookmarks/stations")
     fun bookmarkStation(
-            @RequestBody request: BookmarkStationDto.Request
+        @RequestBody request: BookmarkStationDto.Request
     ): CommonResponse<GetBookmarkStationDto.Response> {
         return CommonResponse.success(memberUseCase.bookmarkStation(request.toCommand()))
     }

--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/dto/DeleteMemberDto.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/dto/DeleteMemberDto.kt
@@ -1,0 +1,18 @@
+package backend.team.ahachul_backend.api.member.adapter.web.`in`.dto
+
+class DeleteMemberDto {
+
+    data class Request(
+        val authorizationHeader: String,
+    ) {
+        val accessToken: String = authorizationHeader.removeAuthPrefix()
+
+        companion object {
+            private const val AUTH_PREFIX = "Bearer "
+
+            private fun String.removeAuthPrefix(): String {
+                return if (this.startsWith(AUTH_PREFIX)) this.substring(AUTH_PREFIX.length) else this
+            }
+        }
+    }
+}

--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/in/MemberUseCase.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/member/application/port/in/MemberUseCase.kt
@@ -12,6 +12,8 @@ interface MemberUseCase {
 
     fun updateMember(command: UpdateMemberCommand): UpdateMemberDto.Response
 
+    fun deleteMember(request: DeleteMemberDto.Request)
+
     fun checkNickname(command: CheckNicknameCommand): CheckNicknameDto.Response
 
     fun bookmarkStation(command: BookmarkStationCommands): GetBookmarkStationDto.Response

--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/member/application/service/AuthService.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/member/application/service/AuthService.kt
@@ -108,6 +108,9 @@ class AuthService(
     override fun getToken(command: GetTokenCommand): GetTokenDto.Response {
         val refreshToken = jwtUtils.verify(command.refreshToken)
 
+        val memberId = refreshToken.body.subject.toLong()
+        memberReader.getMember(memberId)
+
         if (refreshToken.body.expiration.after(Date(System.currentTimeMillis() - sevenDaysInMillis))) {
             return GetTokenDto.Response(
                 accessToken = jwtUtils.createToken(refreshToken.body.subject, jwtProperties.accessTokenExpireTime),

--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/member/application/service/MemberService.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/member/application/service/MemberService.kt
@@ -29,7 +29,8 @@ class MemberService(
     private val memberStationWriter: MemberStationWriter,
     private val memberStationReader: MemberStationReader,
     private val subwayLineStationReader: SubwayLineStationReader,
-    private val fcmTokenWriter: FcmTokenWriter
+    private val fcmTokenWriter: FcmTokenWriter,
+    private val authLogoutCacheUtils: AuthLogoutCacheUtils
 ) : MemberUseCase {
 
     override fun getMember(): GetMemberDto.Response {
@@ -48,6 +49,14 @@ class MemberService(
                 gender = member.gender,
                 ageRange = member.ageRange
         )
+    }
+
+    @Transactional
+    override fun deleteMember(request: DeleteMemberDto.Request) {
+        val member = memberReader.getMember(RequestUtils.getAttribute(RequestUtils.Attribute.MEMBER_ID)!!.toLong())
+        member.delete()
+
+        authLogoutCacheUtils.logout(request.accessToken)
     }
 
     override fun checkNickname(command: CheckNicknameCommand): CheckNicknameDto.Response {

--- a/application/src/test/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/MemberControllerDocsTest.kt
+++ b/application/src/test/kotlin/backend/team/ahachul_backend/api/member/adapter/web/in/MemberControllerDocsTest.kt
@@ -125,6 +125,34 @@ class MemberControllerDocsTest : CommonDocsTestConfig() {
     }
 
     @Test
+    fun deleteMemberTest() {
+        // when
+        val result = mockMvc.perform(
+            delete("/v1/members")
+                .header("Authorization", "Bearer <Access Token>")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+        )
+
+        // then
+        result.andExpect(status().isOk)
+            .andDo(
+                document(
+                    "delete-member",
+                    getDocsRequest(),
+                    getDocsResponse(),
+                    requestHeaders(
+                        headerWithName("Authorization").description("엑세스 토큰")
+                    ),
+                    responseFields(
+                        *commonResponseFields(),
+                        fieldWithPath("result").optional().description("X")
+                    )
+                )
+            )
+    }
+
+    @Test
     fun checkNicknameTest() {
         // given
         val response = CheckNicknameDto.Response(

--- a/application/src/test/kotlin/backend/team/ahachul_backend/api/member/application/service/AuthServiceTest.kt
+++ b/application/src/test/kotlin/backend/team/ahachul_backend/api/member/application/service/AuthServiceTest.kt
@@ -1,12 +1,20 @@
 package backend.team.ahachul_backend.api.member.application.service
 
+import backend.team.ahachul_backend.api.member.adapter.web.out.MemberRepository
 import backend.team.ahachul_backend.api.member.application.port.`in`.AuthUseCase
+import backend.team.ahachul_backend.api.member.application.port.`in`.command.GetTokenCommand
+import backend.team.ahachul_backend.api.member.domain.entity.MemberEntity
+import backend.team.ahachul_backend.api.member.domain.model.GenderType
+import backend.team.ahachul_backend.api.member.domain.model.MemberStatusType
+import backend.team.ahachul_backend.api.member.domain.model.ProviderType
 import backend.team.ahachul_backend.common.exception.CommonException
+import backend.team.ahachul_backend.common.exception.DomainException
 import backend.team.ahachul_backend.common.response.ResponseCode
 import backend.team.ahachul_backend.common.utils.JwtUtils
 import backend.team.ahachul_backend.config.controller.CommonServiceTestConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 
@@ -14,6 +22,7 @@ class AuthServiceTest(
     @Autowired val authUseCase: AuthUseCase,
     @Autowired val authLogoutCacheUtils: AuthLogoutCacheUtils,
     @Autowired val jwtUtils: JwtUtils,
+    @Autowired val memberRepository: MemberRepository,
 ) : CommonServiceTestConfig() {
 
     @Test
@@ -67,5 +76,32 @@ class AuthServiceTest(
         }
             .isExactlyInstanceOf(CommonException::class.java)
             .hasMessage(ResponseCode.ALREADY_LOGOUT_TOKEN.message)
+    }
+
+    @Test
+    @DisplayName("탈퇴한 사용자는 토큰 갱신이 불가능하다.")
+    fun cannotRefreshTokenWithDeleteUser() {
+        // given
+        val member = memberRepository.save(
+            MemberEntity(
+                nickname = "deletetNickname",
+                provider = ProviderType.KAKAO,
+                providerUserId = "providerUserId",
+                email = "email",
+                gender = GenderType.MALE,
+                ageRange = "20",
+                status = MemberStatusType.DELETE
+            )
+        )
+
+        val token = jwtUtils.createToken(member.id.toString(), 100L)
+
+        // when & then
+        assertThatThrownBy {
+            authUseCase.getToken(GetTokenCommand(token))
+        }
+            .isExactlyInstanceOf(DomainException::class.java)
+            .hasMessage(ResponseCode.ALREADY_DELETE_MEMBER.message)
+
     }
 }

--- a/application/src/test/kotlin/backend/team/ahachul_backend/api/member/application/service/MemberServiceTest.kt
+++ b/application/src/test/kotlin/backend/team/ahachul_backend/api/member/application/service/MemberServiceTest.kt
@@ -4,6 +4,7 @@ import backend.team.ahachul_backend.api.common.adapter.web.out.StationRepository
 import backend.team.ahachul_backend.api.common.adapter.web.out.SubwayLineStationRepository
 import backend.team.ahachul_backend.api.common.domain.entity.StationEntity
 import backend.team.ahachul_backend.api.common.domain.entity.SubwayLineStationEntity
+import backend.team.ahachul_backend.api.member.adapter.web.`in`.dto.DeleteMemberDto
 import backend.team.ahachul_backend.api.member.adapter.web.out.MemberRepository
 import backend.team.ahachul_backend.api.member.adapter.web.out.MemberStationRepository
 import backend.team.ahachul_backend.api.member.application.command.BookmarkStationCommand
@@ -12,6 +13,7 @@ import backend.team.ahachul_backend.api.member.application.command.SearchMemberC
 import backend.team.ahachul_backend.api.member.application.port.`in`.MemberUseCase
 import backend.team.ahachul_backend.api.member.application.port.`in`.command.CheckNicknameCommand
 import backend.team.ahachul_backend.api.member.application.port.`in`.command.UpdateMemberCommand
+import backend.team.ahachul_backend.api.member.application.port.out.MemberReader
 import backend.team.ahachul_backend.api.member.application.port.out.MemberWriter
 import backend.team.ahachul_backend.api.member.domain.entity.MemberEntity
 import backend.team.ahachul_backend.api.member.domain.entity.MemberStationEntity
@@ -20,9 +22,12 @@ import backend.team.ahachul_backend.api.member.domain.model.MemberStatusType
 import backend.team.ahachul_backend.api.member.domain.model.ProviderType
 import backend.team.ahachul_backend.common.domain.entity.SubwayLineEntity
 import backend.team.ahachul_backend.common.domain.model.RegionType
+import backend.team.ahachul_backend.common.exception.AdapterException
 import backend.team.ahachul_backend.common.exception.BusinessException
+import backend.team.ahachul_backend.common.exception.DomainException
 import backend.team.ahachul_backend.common.persistence.SubwayLineRepository
 import backend.team.ahachul_backend.common.response.ResponseCode
+import backend.team.ahachul_backend.common.utils.JwtUtils
 import backend.team.ahachul_backend.common.utils.RequestUtils
 import backend.team.ahachul_backend.config.controller.CommonServiceTestConfig
 import org.assertj.core.api.Assertions.*
@@ -36,12 +41,15 @@ import org.springframework.data.repository.findByIdOrNull
 
 class MemberServiceTest(
     @Autowired val memberWriter: MemberWriter,
+    @Autowired val memberReader: MemberReader,
     @Autowired val memberUseCase: MemberUseCase,
     @Autowired val memberRepository: MemberRepository,
     @Autowired val stationRepository: StationRepository,
     @Autowired val memberStationRepository: MemberStationRepository,
     @Autowired val subwayLineStationRepository: SubwayLineStationRepository,
-    @Autowired val subwayLineRepository: SubwayLineRepository
+    @Autowired val subwayLineRepository: SubwayLineRepository,
+    @Autowired val jwtUtils: JwtUtils,
+    @Autowired val authLogoutCacheUtils: AuthLogoutCacheUtils,
 ) : CommonServiceTestConfig() {
 
     var member: MemberEntity? = null
@@ -385,5 +393,83 @@ class MemberServiceTest(
         // then
         val result = memberRepository.findByIdOrNull(member!!.id)
         assertThat(result!!.fcmToken!!.token).isEqualTo(token)
+    }
+
+    @Test
+    @DisplayName("이미 탈퇴된 회원은 털퇴를 할 수 없다")
+    fun cannotDeleteUserWithDeleteUser() {
+        // given
+        val member = memberRepository.save(
+            MemberEntity(
+                nickname = "deletetNickname",
+                provider = ProviderType.KAKAO,
+                providerUserId = "providerUserId",
+                email = "email",
+                gender = GenderType.MALE,
+                ageRange = "20",
+                status = MemberStatusType.DELETE
+            )
+        )
+
+        RequestUtils.setAttribute(RequestUtils.Attribute.MEMBER_ID, member.id)
+        val token = jwtUtils.createToken(member.id.toString(), 100L)
+
+        // when // then
+        assertThatThrownBy {
+            memberUseCase.deleteMember(DeleteMemberDto.Request(token))
+        }
+            .isExactlyInstanceOf(DomainException::class.java)
+            .hasMessage(ResponseCode.ALREADY_DELETE_MEMBER.message)
+    }
+
+    @Test
+    @DisplayName("탈퇴 후, 토큰은 로그아웃된다.")
+    fun logoutTokenAfterDeleteUser() {
+        // given
+        val token = jwtUtils.createToken(member!!.id.toString(), 100L)
+
+        // when
+        memberUseCase.deleteMember(DeleteMemberDto.Request(token))
+
+        // then
+        val notLogout = authLogoutCacheUtils.isNotLogout(token)
+        assertThat(notLogout).isFalse()
+    }
+
+    @Test
+    @DisplayName("사용자를 탈퇴한다.")
+    fun deleteUser() {
+        // given
+        val token = jwtUtils.createToken(member!!.id.toString(), 100L)
+
+        // when
+        memberUseCase.deleteMember(DeleteMemberDto.Request(token))
+        val findMember = memberRepository.findById(member!!.id).get()
+
+        // then
+        assertThat(findMember.isDeleted()).isTrue()
+    }
+
+    @Test
+    @DisplayName("탈퇴 후, 사용자 조회가 불가하다.")
+    fun cannotSelectUserAfterDeleteUser() {
+        // given
+        val token = jwtUtils.createToken(member!!.id.toString(), 100L)
+        memberUseCase.deleteMember(DeleteMemberDto.Request(token))
+
+        // when & then
+        // ID로 조회
+        assertThatThrownBy {
+            memberReader.getMember(member!!.id)
+        }
+            .isExactlyInstanceOf(DomainException::class.java)
+            .hasMessage(ResponseCode.ALREADY_DELETE_MEMBER.message)
+
+        // providerUserId로 조회
+        assertThatThrownBy {
+            memberReader.findMember(member!!.providerUserId)
+        }
+            .isExactlyInstanceOf(DomainException::class.java)
+            .hasMessage(ResponseCode.ALREADY_DELETE_MEMBER.message)
     }
 }

--- a/core/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/out/MemberPersistence.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/api/member/adapter/web/out/MemberPersistence.kt
@@ -5,6 +5,7 @@ import backend.team.ahachul_backend.api.member.application.port.out.MemberReader
 import backend.team.ahachul_backend.api.member.application.port.out.MemberWriter
 import backend.team.ahachul_backend.api.member.domain.entity.MemberEntity
 import backend.team.ahachul_backend.common.exception.AdapterException
+import backend.team.ahachul_backend.common.exception.DomainException
 import backend.team.ahachul_backend.common.response.ResponseCode
 import org.springframework.stereotype.Component
 
@@ -18,12 +19,22 @@ class MemberPersistence(
     }
 
     override fun getMember(memberId: Long): MemberEntity {
-        return memberRepository.findById(memberId)
-                .orElseThrow { throw AdapterException(ResponseCode.INVALID_DOMAIN) }
+        val member = memberRepository.findById(memberId)
+            .orElseThrow { throw AdapterException(ResponseCode.INVALID_DOMAIN) }
+
+        validateMember(member)
+
+        return member
     }
 
     override fun findMember(providerUserId: String): MemberEntity? {
-        return memberRepository.findByProviderUserId(providerUserId)
+        val member = memberRepository.findByProviderUserId(providerUserId)
+
+        member?.let {
+            validateMember(member)
+        }
+
+        return member
     }
 
     override fun existMember(nickname: String): Boolean {
@@ -32,5 +43,11 @@ class MemberPersistence(
 
     override fun searchMembers(command: SearchMemberCommand): List<MemberEntity> {
         return memberRepository.findByNicknameContaining(command.nickname)
+    }
+
+    private fun validateMember(member: MemberEntity) {
+        if (member.isDeleted()) {
+            throw DomainException(ResponseCode.ALREADY_DELETE_MEMBER)
+        }
     }
 }

--- a/core/src/main/kotlin/backend/team/ahachul_backend/api/member/domain/entity/MemberEntity.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/api/member/domain/entity/MemberEntity.kt
@@ -17,30 +17,30 @@ import jakarta.persistence.*
 
 @Entity
 class MemberEntity(
-        @Id
-        @GeneratedValue(strategy = GenerationType.IDENTITY)
-        @Column(name = "member_id")
-        val id: Long = 0,
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    val id: Long = 0,
 
-        var nickname: String?,
+    var nickname: String?,
 
-        val providerUserId: String,
+    val providerUserId: String,
 
-        @Enumerated(EnumType.STRING)
-        val provider: ProviderType,
+    @Enumerated(EnumType.STRING)
+    val provider: ProviderType,
 
-        var email: String?,
+    var email: String?,
 
-        @Enumerated(EnumType.STRING)
-        var gender: GenderType?,
+    @Enumerated(EnumType.STRING)
+    var gender: GenderType?,
 
-        var ageRange: String?,
+    var ageRange: String?,
 
-        @Enumerated(EnumType.STRING)
-        var status: MemberStatusType,
+    @Enumerated(EnumType.STRING)
+    var status: MemberStatusType,
 
-        @Enumerated(EnumType.STRING)
-        var regionType: RegionType = RegionType.METROPOLITAN,
+    @Enumerated(EnumType.STRING)
+    var regionType: RegionType = RegionType.METROPOLITAN,
 
     @OneToMany(mappedBy = "targetMember")
     var memberReports: MutableList<ReportEntity> = mutableListOf(),
@@ -49,68 +49,76 @@ class MemberEntity(
     var fcmToken: FcmTokenEntity? = null,
 ) : BaseEntity() {
 
-        companion object {
-                fun ofKakao(command: LoginMemberCommand, userInfo: KakaoMemberInfoDto): MemberEntity {
-                        return MemberEntity(
-                                nickname = null,
-                                providerUserId = userInfo.id,
-                                provider = command.providerType,
-                                email = userInfo.kakaoAccount.email,
-                                gender = userInfo.kakaoAccount.gender?.let { GenderType.of(it) },
-                                ageRange = userInfo.kakaoAccount.ageRange?.let { it.split("~")[0] },
-                                status = MemberStatusType.ACTIVE,
-                        )
-                }
-
-                fun ofGoogle(command: LoginMemberCommand, userInfo: GoogleUserInfoDto): MemberEntity {
-                        return MemberEntity(
-                                nickname = null,
-                                providerUserId = userInfo.id,
-                                provider = command.providerType,
-                                email = userInfo.email,
-                                gender = null,
-                                ageRange = null,
-                                status = MemberStatusType.ACTIVE
-                        )
-                }
-
-                fun ofApple(command: LoginMemberCommand, userInfo: AppleUserInfoDto): MemberEntity {
-                        return MemberEntity(
-                                nickname = null,
-                                providerUserId = userInfo.sub,
-                                provider = command.providerType,
-                                email = null,
-                                gender = null,
-                                ageRange = null,
-                                status = MemberStatusType.ACTIVE
-                        )
-                }
+    companion object {
+        fun ofKakao(command: LoginMemberCommand, userInfo: KakaoMemberInfoDto): MemberEntity {
+            return MemberEntity(
+                nickname = null,
+                providerUserId = userInfo.id,
+                provider = command.providerType,
+                email = userInfo.kakaoAccount.email,
+                gender = userInfo.kakaoAccount.gender?.let { GenderType.of(it) },
+                ageRange = userInfo.kakaoAccount.ageRange?.let { it.split("~")[0] },
+                status = MemberStatusType.ACTIVE,
+            )
         }
 
-        fun changeNickname(nickname: String) {
-                this.nickname = nickname
+        fun ofGoogle(command: LoginMemberCommand, userInfo: GoogleUserInfoDto): MemberEntity {
+            return MemberEntity(
+                nickname = null,
+                providerUserId = userInfo.id,
+                provider = command.providerType,
+                email = userInfo.email,
+                gender = null,
+                ageRange = null,
+                status = MemberStatusType.ACTIVE
+            )
         }
 
-        fun changeGender(gender: GenderType) {
-                this.gender = gender
+        fun ofApple(command: LoginMemberCommand, userInfo: AppleUserInfoDto): MemberEntity {
+            return MemberEntity(
+                nickname = null,
+                providerUserId = userInfo.sub,
+                provider = command.providerType,
+                email = null,
+                gender = null,
+                ageRange = null,
+                status = MemberStatusType.ACTIVE
+            )
         }
+    }
 
-        fun changeAgeRange(ageRange: String) {
-                this.ageRange = ageRange
-        }
+    fun changeNickname(nickname: String) {
+        this.nickname = nickname
+    }
 
-        fun isNeedAdditionalUserInfo(): Boolean {
-                return nickname == null
-        }
+    fun changeGender(gender: GenderType) {
+        this.gender = gender
+    }
 
-        fun isConditionsMetToBlock(reportedCount: Int): Boolean {
-                return memberReports.size >= reportedCount
-        }
+    fun changeAgeRange(ageRange: String) {
+        this.ageRange = ageRange
+    }
 
-        fun blockMember() {
-                if (status == MemberStatusType.SUSPENDED) {
-                        throw DomainException(ResponseCode.INVALID_REPORT_ACTION)
-                }
-                this.status = MemberStatusType.SUSPENDED
+    fun isNeedAdditionalUserInfo(): Boolean {
+        return nickname == null
+    }
+
+    fun isConditionsMetToBlock(reportedCount: Int): Boolean {
+        return memberReports.size >= reportedCount
+    }
+
+    fun blockMember() {
+        if (status == MemberStatusType.SUSPENDED) {
+            throw DomainException(ResponseCode.INVALID_REPORT_ACTION)
         }
+        this.status = MemberStatusType.SUSPENDED
+    }
+
+    fun delete() {
+        this.status = MemberStatusType.DELETE
+    }
+
+    fun isDeleted(): Boolean {
+        return status == MemberStatusType.DELETE
+    }
 }

--- a/core/src/main/kotlin/backend/team/ahachul_backend/common/response/ResponseCode.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/common/response/ResponseCode.kt
@@ -24,7 +24,7 @@ enum class ResponseCode(
     INVALID_AUTH("207", "권한이 없습니다.", HttpStatus.FORBIDDEN),
     FAILED_TO_CONNECT_TO_REDIS("208", "통신 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     ALREADY_LOGOUT_TOKEN("209", "이미 로그아웃된 토큰입니다.", HttpStatus.UNAUTHORIZED),
-
+    ALREADY_DELETE_MEMBER("210", "이미 탈퇴된 회원입니다.", HttpStatus.FORBIDDEN),
 
     // REPORT
     INVALID_REPORT_REQUEST("300", "본인의 게시물은 신고할 수 없습니다.", HttpStatus.BAD_REQUEST),


### PR DESCRIPTION
## 📚 개요
+ #359 

## ✏️ 작업 내용
- 회원 탈퇴 API 구현 및 로그아웃 구현
- 로그인 시, 회원 탈퇴 검증 로직 추가
- 토큰 재발급 시, 회원 탈퇴 검증 로직 추가
- 회원 조회 시, 회원 탈퇴 검증 `findMember()`로직 추가

## 💡 주의 사항
+ 회원을 조회하는 메서드에 탈퇴 검증 로직을 추가해서 사이드 이펙트가 있을 수 있습니다. 
문제가 되는 부분있으면 공유 부탁드립니다. 
