### PR TITLE
:bug: JWT 만료 기간을 월에서 시간 단위로 변경 (#363)

### DIFF
--- a/application/src/main/kotlin/backend/team/ahachul_backend/common/client/impl/AppleMemberClientImpl.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/common/client/impl/AppleMemberClientImpl.kt
@@ -78,7 +78,7 @@ class AppleMemberClientImpl(
             .setHeaderParam("kid", properties.kid)
             .setIssuer(properties.iss)
             .setIssuedAt(localDateTimeToDate(now))
-            .setExpiration(localDateTimeToDate(now.plusMonths(6)))
+            .setExpiration(localDateTimeToDate(now.plusHours(6)))
             .setSubject(properties.sub)
             .setAudience(properties.aud)
             .signWith(getKey(), ES256)


### PR DESCRIPTION
## 📚 개요
+ #363 

## ✏️ 작업 내용
+ 애플 로그인이 안되는 버그 해결 - `client_secret` 파라미터를 생성하는 과정에서 JWT 만료일자를 변경하였습니다.

