### PR TITLE
:recycle: 유실물 검색 쿼리 full-text-search 인덱스 도입 (#366)

### DIFF
--- a/core/src/main/kotlin/backend/team/ahachul_backend/api/lost/adapter/web/out/CustomLostPostRepository.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/api/lost/adapter/web/out/CustomLostPostRepository.kt
@@ -9,7 +9,9 @@ import backend.team.ahachul_backend.api.lost.domain.model.LostOrigin
 import backend.team.ahachul_backend.api.lost.domain.model.LostPostType
 import backend.team.ahachul_backend.api.lost.domain.model.LostStatus
 import backend.team.ahachul_backend.api.lost.domain.model.LostType
+import backend.team.ahachul_backend.common.config.MatchFunctionContributor
 import backend.team.ahachul_backend.common.domain.entity.SubwayLineEntity
+import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.core.types.dsl.Expressions
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.jdbc.core.JdbcTemplate
@@ -72,13 +74,13 @@ class CustomLostPostRepository(
                 subwayLinesEq(command.subwayLines),
                 lostTypeEq(command.lostType),
                 categoryEq(command.category),
-                titleAndContentLike(command.keyword),
+                typeNotEq(LostPostType.DELETED),
+                booleanMatch(command.keyword),
                 createdAtBeforeOrEqual(
                     command.lostType,
                     command.date,
                     command.lostPostId
-                ),
-                typeNotEq(LostPostType.DELETED)
+                )
             )
             .orderBy(*orderSpecifier.toTypedArray())
             .limit((command.pageSize + 1).toLong())
@@ -125,6 +127,7 @@ class CustomLostPostRepository(
     private fun categoryNotEq(category: CategoryEntity?) =
         category?.let { lostPostEntity.category.ne(category) }
 
+    @Deprecated("changed to full-text-search", ReplaceWith("booleanMatch(keyword)"))
     private fun titleAndContentLike(keyword: String?) =
         keyword?.let {
             lostPostEntity.title.contains(keyword)
@@ -133,7 +136,6 @@ class CustomLostPostRepository(
 
     private fun typeNotEq(type: LostPostType?) =
         type?.let { lostPostEntity.type.ne(type) }
-
 
     private fun createdAtBeforeOrEqual(lostType: LostType, localDateTime: LocalDateTime?, id: Long?) =
         if (lostType == LostType.ACQUIRE) {
@@ -153,4 +155,20 @@ class CustomLostPostRepository(
                 }
             }
         }
+
+    /**
+     * n-gram(default 2) parsing + search boolean mode(+)
+     */
+    private fun booleanMatch(keyword: String?): BooleanExpression? {
+        if (keyword.isNullOrBlank()) return null
+
+        val booleanQuery = "+$keyword"
+        return Expressions.numberTemplate(
+            Double::class.java,
+            "match_boolean({0}, {1}, {2})",
+            lostPostEntity.title,
+            lostPostEntity.content,
+            booleanQuery
+        ).gt(0)
+    }
 }

--- a/core/src/main/kotlin/backend/team/ahachul_backend/api/lost/adapter/web/out/CustomLostPostRepository.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/api/lost/adapter/web/out/CustomLostPostRepository.kt
@@ -75,7 +75,7 @@ class CustomLostPostRepository(
                 lostTypeEq(command.lostType),
                 categoryEq(command.category),
                 typeNotEq(LostPostType.DELETED),
-                booleanMatch(command.keyword),
+                naturalMatch(command.keyword),
                 createdAtBeforeOrEqual(
                     command.lostType,
                     command.date,
@@ -157,18 +157,21 @@ class CustomLostPostRepository(
         }
 
     /**
-     * n-gram(default 2) parsing + search boolean mode(+)
+     * n-gram parsing(default 2) + natural language search
      */
-    private fun booleanMatch(keyword: String?): BooleanExpression? {
+    private fun naturalMatch(keyword: String?): BooleanExpression? {
         if (keyword.isNullOrBlank()) return null
 
-        val booleanQuery = "+$keyword"
-        return Expressions.numberTemplate(
-            Double::class.java,
-            "match_boolean({0}, {1}, {2})",
-            lostPostEntity.title,
-            lostPostEntity.content,
-            booleanQuery
-        ).gt(0)
+        return runCatching {
+            Expressions.numberTemplate(
+                Double::class.java,
+                "match_natural({0}, {1}, {2})",
+                lostPostEntity.title,
+                lostPostEntity.content,
+                keyword
+            ).gt(0)
+        }.getOrElse {
+            titleAndContentLike(keyword)
+        }
     }
 }

--- a/core/src/main/kotlin/backend/team/ahachul_backend/common/config/MatchFunctionContributor.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/common/config/MatchFunctionContributor.kt
@@ -2,21 +2,27 @@ package backend.team.ahachul_backend.common.config
 
 import org.hibernate.boot.model.FunctionContributions
 import org.hibernate.boot.model.FunctionContributor
+import org.hibernate.type.BasicTypeReference
+import org.hibernate.type.SqlTypes
 import org.hibernate.type.StandardBasicTypes
 import org.springframework.stereotype.Component
 
-@Component
 class MatchFunctionContributor : FunctionContributor {
 
     override fun contributeFunctions(functionContributions: FunctionContributions) {
-
         val functionRegistry = functionContributions.functionRegistry
-        val typeRegistry = functionContributions.typeConfiguration.basicTypeRegistry
-        val doubleType = typeRegistry.resolve(StandardBasicTypes.DOUBLE)
+
+        val doubleType = functionContributions.typeConfiguration
+            .basicTypeRegistry
+            .resolve(BasicTypeReference(
+                "double",
+                Double::class.java,
+                SqlTypes.DOUBLE
+           ))
 
         functionRegistry.registerPattern(
-            "match_boolean",
-            "MATCH(?1, ?2) AGAINST (?3 IN BOOLEAN MODE)",
+            "match_natural",
+            "MATCH(?1, ?2) AGAINST (?3 IN NATURAL LANGUAGE MODE)",
             doubleType
         )
     }

--- a/core/src/main/kotlin/backend/team/ahachul_backend/common/config/MatchFunctionContributor.kt
+++ b/core/src/main/kotlin/backend/team/ahachul_backend/common/config/MatchFunctionContributor.kt
@@ -1,0 +1,23 @@
+package backend.team.ahachul_backend.common.config
+
+import org.hibernate.boot.model.FunctionContributions
+import org.hibernate.boot.model.FunctionContributor
+import org.hibernate.type.StandardBasicTypes
+import org.springframework.stereotype.Component
+
+@Component
+class MatchFunctionContributor : FunctionContributor {
+
+    override fun contributeFunctions(functionContributions: FunctionContributions) {
+
+        val functionRegistry = functionContributions.functionRegistry
+        val typeRegistry = functionContributions.typeConfiguration.basicTypeRegistry
+        val doubleType = typeRegistry.resolve(StandardBasicTypes.DOUBLE)
+
+        functionRegistry.registerPattern(
+            "match_boolean",
+            "MATCH(?1, ?2) AGAINST (?3 IN BOOLEAN MODE)",
+            doubleType
+        )
+    }
+}

--- a/core/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
+++ b/core/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
@@ -1,0 +1,1 @@
+backend.team.ahachul_backend.common.config.MatchFunctionContributor

--- a/core/src/main/resources/db/migration/V202511160600__add_ftx_index.sql
+++ b/core/src/main/resources/db/migration/V202511160600__add_ftx_index.sql
@@ -1,0 +1,1 @@
+CREATE FULLTEXT INDEX ft_index ON tb_lost_post(title, content) WITH PARSER ngram;


### PR DESCRIPTION
## 📚 개요
+ #366 

## ✏️ 작업 내용
+ full-text-search 인덱스 추가
+ 현재 기준으로는 60만건 `4초 -> 0.8초`로 감소, 내림차순 인덱스(`0.3초`)에 비해 느리지만 고정적인 성능 향상이 가능

## 💡 주의 사항
+ 논의 사항을 작성해 주세요.
+ 중점적으로 리뷰받고 싶은 내용을 작성해 주세요.
