### PR TITLE
fix(auth): Google OAuth 로그인 예외를 도메인 응답으로 정규화

### DIFF
--- a/application/src/main/kotlin/backend/team/ahachul_backend/common/CommonExceptionHandler.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/common/CommonExceptionHandler.kt
@@ -6,6 +6,7 @@ import backend.team.ahachul_backend.common.response.CommonResponse
 import backend.team.ahachul_backend.common.response.ResponseCode
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.web.HttpRequestMethodNotSupportedException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 
@@ -22,6 +23,16 @@ class CommonExceptionHandler {
                 ex = e
         )
         return ResponseEntity(CommonResponse.fail(), HttpStatus.INTERNAL_SERVER_ERROR)
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException::class)
+    fun methodNotSupportedException(e: HttpRequestMethodNotSupportedException): ResponseEntity<CommonResponse<Unit>> {
+        logger.error(
+                message = e.message,
+                code = ResponseCode.BAD_REQUEST,
+                ex = e
+        )
+        return ResponseEntity(CommonResponse.fail(ResponseCode.BAD_REQUEST), HttpStatus.METHOD_NOT_ALLOWED)
     }
 
     @ExceptionHandler(CommonException::class)

--- a/application/src/main/kotlin/backend/team/ahachul_backend/common/client/impl/GoogleMemberClientImpl.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/common/client/impl/GoogleMemberClientImpl.kt
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.http.*
 import org.springframework.stereotype.Component
 import org.springframework.util.LinkedMultiValueMap
+import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.RestTemplate
 import java.util.*
 
@@ -32,7 +33,11 @@ class GoogleMemberClientImpl(
             contentType = MediaType.APPLICATION_FORM_URLENCODED
         }
         val httpEntity = HttpEntity(getHttpBodyParams(code, origin), headers)
-        val response = restTemplate.exchange(provider.tokenUri, HttpMethod.POST, httpEntity, String::class.java)
+        val response = try {
+            restTemplate.exchange(provider.tokenUri, HttpMethod.POST, httpEntity, String::class.java)
+        } catch (e: HttpClientErrorException) {
+            throw CommonException(ResponseCode.INVALID_OAUTH_AUTHORIZATION_CODE, e)
+        }
 
         if (response.statusCode == HttpStatus.OK) {
             return objectMapper.readValue(response.body, GoogleAccessTokenDto::class.java).accessToken
@@ -55,7 +60,11 @@ class GoogleMemberClientImpl(
             setBearerAuth(accessToken)
         }
         val httpEntity = HttpEntity<Any>(headers)
-        val response = restTemplate.exchange(provider.userInfoUri!!, HttpMethod.GET, httpEntity, String::class.java)
+        val response = try {
+            restTemplate.exchange(provider.userInfoUri!!, HttpMethod.GET, httpEntity, String::class.java)
+        } catch (e: HttpClientErrorException) {
+            throw CommonException(ResponseCode.INVALID_OAUTH_ACCESS_TOKEN, e)
+        }
 
         if (response.statusCode == HttpStatus.OK) {
             return objectMapper.readValue(response.body, GoogleUserInfoDto::class.java)


### PR DESCRIPTION
## 변경 배경
Google OAuth 로그인 과정에서 외부 API 4xx/메서드 불일치가 내부 500으로 노출될 수 있어, 인증 실패 원인에 맞는 도메인 응답으로 정규화가 필요했습니다.

## 주요 변경 사항
- `GoogleMemberClientImpl`
  - Google 토큰 교환/유저 정보 조회 시 `HttpClientErrorException`을 캐치
  - 각각 `INVALID_OAUTH_AUTHORIZATION_CODE`, `INVALID_OAUTH_ACCESS_TOKEN`으로 매핑
- `CommonExceptionHandler`
  - `HttpRequestMethodNotSupportedException` 핸들러 추가
  - 메서드 불일치 시 `METHOD_NOT_ALLOWED` 상태로 명시적 응답

## 기대 효과
- OAuth 실패 시 원인 기반 응답 코드 노출
- 메서드 불일치가 generic 500으로 처리되는 문제 완화
- 로그인 트러블슈팅 시 관측성 개선

## 검증
- 컴파일 통과: `./gradlew :application:compileKotlin`
- 로컬 실행 확인: `./gradlew :application:bootRun --args='--spring.profiles.active=local'`

## 영향 범위
- `/application/src/main/kotlin/backend/team/ahachul_backend/common/client/impl/GoogleMemberClientImpl.kt`
- `/application/src/main/kotlin/backend/team/ahachul_backend/common/CommonExceptionHandler.kt`
