### PR TITLE
[BE] local bootRun 표준화 및 logback safe default 적용

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,23 @@
 <img width="836" height="482" alt="스크린샷 2025-11-18 오후 3 55 54" src="https://github.com/user-attachments/assets/61b29c06-e5fa-4634-b108-b840aa03d09a" />
 " />
 
+## 로컬 실행(표준)
+
+### application 모듈
+
+```bash
+./gradlew :application:bootRun --args='--spring.profiles.active=local'
+```
+
+- 추가 env 없이 실행 가능합니다.
+- `local` 기본 DB는 `jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE` 입니다.
+- `HASHTAG_SOCKET` 로깅은 기본적으로 `localhost:5001`을 사용합니다.
+- 8080 포트가 이미 사용 중이면 다음처럼 포트를 지정합니다.
+
+```bash
+./gradlew :application:bootRun --args='--spring.profiles.active=local --server.port=18080'
+```
+
 
 
 ## ERD 

--- a/application/src/main/resources/logback-spring.xml
+++ b/application/src/main/resources/logback-spring.xml
@@ -15,15 +15,13 @@
     <property name="HASHTAG_LOG_PATH" value="${log.config.hashtag.path}"/>
     <property name="HASHTAG_LOG_FILE_NAME" value="${log.config.hashtag.filename}"/>
 
+    <property name="HASHTAG_LOG_HOST_NAME" value="${log.config.hashtag.hostname.local:-localhost}"/>
+
     <springProfile name="dev">
         <property name="HASHTAG_LOG_HOST_NAME" value="${log.config.hashtag.hostname}"/>
     </springProfile>
 
-    <springProfile name="local, test">
-        <property name="HASHTAG_LOG_HOST_NAME" value="${log.config.hashtag.hostname.local}"/>
-    </springProfile>
-
-    <property name="HASHTAG_LOG_PORT" value="${log.config.hashtag.port}"/>
+    <property name="HASHTAG_LOG_PORT" value="${log.config.hashtag.port:-5001}"/>
 
     <property name="LOG_PATTERN" value="%-5level %d{yy-MM-dd HH:mm:ss}[%thread] [%logger{0}:%line] - %msg%n"/>
     <property name="HASHTAG_LOG_PATTERN" value="%d{yy-MM-dd HH:mm:ss} [%logger{0}:%line] %msg%n"/>

--- a/docs/governance/BACKEND_DB_INFRA_EXECUTION_CHECKLIST.md
+++ b/docs/governance/BACKEND_DB_INFRA_EXECUTION_CHECKLIST.md
@@ -39,6 +39,9 @@ aws sts get-caller-identity
 # backend 기본 검증(레포 루트 기준)
 ./gradlew test
 
+# backend application 로컬 실행(추가 env 없이)
+./gradlew :application:bootRun --args='--spring.profiles.active=local'
+
 # data repo 기본 실행 예시
 python main.py -o ca
 python main.py -o un
@@ -49,4 +52,3 @@ python main.py -o ad -d 20260101
 - AWS 계정 불일치 상태에서 실제 리소스 접근이 필요한 명령을 실행하려는 경우 즉시 중단.
 - 시크릿 값이 필요하지만 안전한 소스(ahachul_secret/env) 없이 하드코딩하려는 경우 즉시 중단.
 - Flyway 없이 DB 수동 변경으로 진행하려는 경우 즉시 중단.
-

--- a/docs/governance/BACKEND_DB_INFRA_RULEBOOK_CHANGELOG.md
+++ b/docs/governance/BACKEND_DB_INFRA_RULEBOOK_CHANGELOG.md
@@ -5,4 +5,4 @@
 - `ahhachul_backend`, `ahachul_data`, `ahachul_secret` 기준 아키텍처/컨벤션/운영 규칙 통합.
 - AWS 계정 안전 규칙(회사 default 계정 사용 금지) 명문화.
 - 실행 점검용 `BACKEND_DB_INFRA_EXECUTION_CHECKLIST.md` 추가.
-
+- `BACKEND_DB_INFRA_EXECUTION_CHECKLIST.md`에 backend local 표준 실행 명령(`:application:bootRun --spring.profiles.active=local`) 추가.


### PR DESCRIPTION
## 변경 사항
- `application/src/main/resources/logback-spring.xml`에 `HASHTAG_LOG_HOST_NAME`/`HASHTAG_LOG_PORT` safe default 적용
- README에 local 표준 실행 명령(`./gradlew :application:bootRun --args='--spring.profiles.active=local'`) 문서화
- 실행 체크리스트/룰북 changelog에 동일 표준 명령 반영

## 배경
- 무프로필 실행 시 `HASHTAG_LOG_HOST_NAME_IS_UNDEFINED`로 부팅 실패하던 이슈 대응
- 로컬 실행 절차를 env 없이 재현 가능하도록 정리

## 검증
- `./gradlew :application:bootRun --args='--spring.profiles.active=local'` 기동 확인
