### PR TITLE
:recycle: 열차 도착정보 중간 새로고침 시 절대 시간 유지하도록 (#383)

### DIFF
--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/train/adapter/in/dto/GetTrainRealTimesDto.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/train/adapter/in/dto/GetTrainRealTimesDto.kt
@@ -11,41 +11,54 @@ class GetTrainRealTimesDto {
         val stationId: Long,
         val subwayLineId: Long,
         val upDownType: UpDownType?
-    ) {
-    }
+    )
 
     data class Response(
         val trainRealTimes: List<TrainRealTime>,
-    ) {
-    }
+    )
 
     data class TrainRealTime(
         @JsonIgnore
         val subwayId: String?,
         @JsonIgnore
-        val stationOrder: Int?,
+        val arrivalSeconds: Long,
         val upDownType: UpDownType,
         val nextStationDirection: String,
         val destinationStationDirection: String,
         val trainNum: String,
-        val currentArrivalTime: Int,
+        val currentArrivalTime: Long,
         val currentTrainArrivalCode: TrainArrivalCode,
     ) {
 
         companion object {
-            fun of(it: RealtimeArrivalListDTO, stationOrder: Int): TrainRealTime {
-                val trainDirection = it.trainLineNm.split("-")
+            fun of(dto: RealtimeArrivalListDTO): TrainRealTime {
+                val barvlDt = dto.barvlDt?.toLongOrNull() ?: 0L
+                val arrivalSeconds = computeArrivalSeconds(barvlDt, dto.arvlMsg2)
+                val trainDirection = dto.trainLineNm.split("-")
                 return TrainRealTime(
-                    subwayId = it.subwayId,
-                    stationOrder = stationOrder,
-                    upDownType = UpDownType.from(it.updnLine),
+                    subwayId = dto.subwayId,
+                    arrivalSeconds = arrivalSeconds,
+                    upDownType = UpDownType.from(dto.updnLine),
                     nextStationDirection = trainDirection[1].trim(),
                     destinationStationDirection = trainDirection[0].trim(),
-                    trainNum = it.btrainNo,
-                    currentArrivalTime = if (stationOrder == Int.MAX_VALUE) { 0 } else stationOrder,
-                    currentTrainArrivalCode = TrainArrivalCode.from(it.arvlCd)
+                    trainNum = dto.btrainNo,
+                    currentArrivalTime = System.currentTimeMillis() / 1000 + arrivalSeconds,
+                    currentTrainArrivalCode = TrainArrivalCode.from(dto.arvlCd)
                 )
             }
+
+            private fun computeArrivalSeconds(barvlDt: Long, arvlMsg2: String): Long {
+                if (barvlDt > 0) return barvlDt
+                // barvlDt = 0이지만 [N]번째 전역인 경우 → 역당 150초로 추정
+                val match = DISTANT_STATION_PATTERN.find(arvlMsg2)
+                if (match != null) {
+                    return match.groupValues[1].toLong() * SECONDS_PER_STATION
+                }
+                return 0L
+            }
+
+            private val DISTANT_STATION_PATTERN = "\\[(\\d+)\\]번째".toRegex()
+            private const val SECONDS_PER_STATION = 150L  // 역당 2분 30초 추정
         }
     }
 }

--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/train/application/service/CongestionCacheUtils.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/train/application/service/CongestionCacheUtils.kt
@@ -58,19 +58,12 @@ class CongestionCacheUtils(
         return localCache.getIfPresent(createKey(subwayLineId, trainNo))
     }
 
-    fun getLocalCache(
-        subwayLineId: Long,
-        trainNo: String
-    ): GetCongestionDto.Response? {
-        return localCache.getIfPresent(createKey(subwayLineId, trainNo))
-    }
-
     private fun createKey(subwayLineId: Long, trainNo: String): String {
         return "${TRAIN_CONGESTION_REDIS_PREFIX}${subwayLineId}-$trainNo"
     }
 
     companion object {
         const val TRAIN_CONGESTION_REDIS_PREFIX = "TRAIN_CONGESTION:"
-        const val TRAIN_CONGESTION_EXPIRE_SEC = 20L
+        const val TRAIN_CONGESTION_EXPIRE_SEC = 15L
     }
 }

--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/train/application/service/TrainCacheUtils.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/train/application/service/TrainCacheUtils.kt
@@ -61,6 +61,6 @@ class TrainCacheUtils(
 
     companion object {
         const val TRAIN_REAL_TIME_REDIS_PREFIX = "TRAIN_TIME:"
-        const val TRAIN_REAL_TIME_EXPIRE_SEC = 20L
+        const val TRAIN_REAL_TIME_EXPIRE_SEC = 15L
     }
 }

--- a/application/src/main/kotlin/backend/team/ahachul_backend/api/train/application/service/TrainService.kt
+++ b/application/src/main/kotlin/backend/team/ahachul_backend/api/train/application/service/TrainService.kt
@@ -169,25 +169,27 @@ class TrainService(
                 val subIdx = if (map.value.size >= 2) 2 else 1
 
                 val lis = map.value.map { dto ->
-                        GetTrainRealTimesDto.TrainRealTime.of(dto, extractStationOrder(dto.arvlMsg2))
+                        GetTrainRealTimesDto.TrainRealTime.of(dto).also { train ->
+                            val remaining = train.currentArrivalTime - System.currentTimeMillis() / 1000
+                            val remainingMin = remaining / 60
+                            val remainingSec = remaining % 60
+                            logger.info(
+                                "[열차 도착 정보] trainNum=${train.trainNum}, " +
+                                "upDownType=${train.upDownType}, " +
+                                "arrivalCode=${train.currentTrainArrivalCode}, " +
+                                "barvlDt(arrivalSeconds)=${train.arrivalSeconds / 60}분 ${train.arrivalSeconds % 60}초, " +
+                                "currentArrivalTime=${train.currentArrivalTime}, " +
+                                "remaining=${remainingMin}분 ${remainingSec}초"
+                            )
+                        }
                     }.sortedWith(compareBy(
                         { it.currentTrainArrivalCode.priority },
-                        { it.stationOrder }
+                        { it.arrivalSeconds }
                     )).subList(0, subIdx)
 
                 total.addAll(lis)
             }
         return total
-    }
-
-    private fun extractStationOrder(destinationMessage: String): Int {
-        return if (destinationMessage.startsWith("[")) {
-            pattern.find(destinationMessage)!!.value.toInt().times(2)
-        } else if (destinationMessage.contains("분")) {
-            pattern.find(destinationMessage)!!.value.toInt()
-        } else {
-            Int.MAX_VALUE
-        }
     }
 
     /**
@@ -279,6 +281,5 @@ class TrainService(
 
     companion object {
         const val DELIMITER = "|"
-        val pattern = "\\d+".toRegex()
     }
 }

--- a/application/src/test/kotlin/backend/team/ahachul_backend/api/train/adapter/in/TrainControllerDocsTest.kt
+++ b/application/src/test/kotlin/backend/team/ahachul_backend/api/train/adapter/in/TrainControllerDocsTest.kt
@@ -135,7 +135,7 @@ class TrainControllerDocsTest : CommonDocsTestConfig() {
         val trainRealTimes = listOf(
             GetTrainRealTimesDto.TrainRealTime(
                 subwayId = "",
-                stationOrder = 1,
+                arrivalSeconds = 0L,
                 upDownType = UpDownType.UP,
                 nextStationDirection = "신대방방면",
                 destinationStationDirection = "성수행",
@@ -145,7 +145,7 @@ class TrainControllerDocsTest : CommonDocsTestConfig() {
             ),
             GetTrainRealTimesDto.TrainRealTime(
                 subwayId = "",
-                stationOrder = 1,
+                arrivalSeconds = 6L,
                 upDownType = UpDownType.UP,
                 nextStationDirection = "봉천방면",
                 destinationStationDirection = "성수행",


### PR DESCRIPTION
## 📚 개요
+ #383 

## ✏️ 작업 내용
+ 캐시 만료되기 전 클라이언트에서 다시 새로고침을 해도 영향 받지 않고 기존의 시간을 보여주도록 수정
+ ex) 3분 30초 -> 5초 후 새로고침 -> 3분 30초(캐시 반환값)이 아닌 3분 25초 반환

## 💡 주의 사항
+ 논의 사항을 작성해 주세요.
+ 중점적으로 리뷰받고 싶은 내용을 작성해 주세요.
